### PR TITLE
Bugfixing in rdf 2 owl translator and owl 2 datalog

### DIFF
--- a/.github/workflows/shared_build_workflow.yml
+++ b/.github/workflows/shared_build_workflow.yml
@@ -36,10 +36,10 @@ jobs:
 
       - name: Download external test files
         run: |
-          parallel ::: \
-            'curl -o test/Api.Tests/TestData/imf.ttl http://ns.imfid.org/20240531/imf-ontology.owl.ttl' \
-            'curl -o test/Api.Tests/TestData/go.owl.xml http://current.geneontology.org/ontology/go.owl' \ 
-            'curl -o "test/Api.Tests/TestData/LIS-14.ttl" "https://rds.posccaesar.org/ontology/lis14/ont/core/4.0/LIS-14.ttl"'
+          curl -o test/Api.Tests/TestData/imf.ttl http://ns.imfid.org/20240531/imf-ontology.owl.ttl &
+          curl -o test/Api.Tests/TestData/go.owl.xml http://current.geneontology.org/ontology/go.owl &
+          curl -o "test/Api.Tests/TestData/LIS-14.ttl" https://rds.posccaesar.org/ontology/lis14/ont/core/4.0/LIS-14.ttl &
+          wait
           ./apache-jena-5.3.0/bin/riot --output=TURTLE test/Api.Tests/TestData/go.owl.xml > test/Api.Tests/TestData/go.ttl
 
       - name: Format code

--- a/.github/workflows/shared_build_workflow.yml
+++ b/.github/workflows/shared_build_workflow.yml
@@ -37,8 +37,9 @@ jobs:
       - name: Download external test files
         run: |
           parallel ::: \
-          "curl -o test/Api.Tests/TestData/imf.ttl http://ns.imfid.org/20240531/imf-ontology.owl.ttl" \
+          "curl -o test/Api.Tests/TestData/imf.ttl http://ns.imfid.org/20240531/imf-ontology.owl.ttl" 
           "curl -o test/Api.Tests/TestData/go.owl.xml http://current.geneontology.org/ontology/go.owl"
+          "curl -o test/Api.Tests/TestData/LIS-14.ttl https://rds.posccaesar.org/ontology/lis14/ont/core/4.0/LIS-14.ttl"
           ./apache-jena-5.2.0/bin/riot --output=TURTLE test/Api.Tests/TestData/go.owl.xml > test/Api.Tests/TestData/go.ttl
 
       - name: Format code

--- a/.github/workflows/shared_build_workflow.yml
+++ b/.github/workflows/shared_build_workflow.yml
@@ -37,9 +37,9 @@ jobs:
       - name: Download external test files
         run: |
           parallel ::: \
-          "curl -o test/Api.Tests/TestData/imf.ttl http://ns.imfid.org/20240531/imf-ontology.owl.ttl" 
-          "curl -o test/Api.Tests/TestData/go.owl.xml http://current.geneontology.org/ontology/go.owl"
-          "curl -o test/Api.Tests/TestData/LIS-14.ttl https://rds.posccaesar.org/ontology/lis14/ont/core/4.0/LIS-14.ttl"
+            'curl -o test/Api.Tests/TestData/imf.ttl http://ns.imfid.org/20240531/imf-ontology.owl.ttl' \
+            'curl -o test/Api.Tests/TestData/go.owl.xml http://current.geneontology.org/ontology/go.owl' \ 
+            'curl -o "test/Api.Tests/TestData/LIS-14.ttl" "https://rds.posccaesar.org/ontology/lis14/ont/core/4.0/LIS-14.ttl"'
           ./apache-jena-5.3.0/bin/riot --output=TURTLE test/Api.Tests/TestData/go.owl.xml > test/Api.Tests/TestData/go.ttl
 
       - name: Format code

--- a/.github/workflows/shared_build_workflow.yml
+++ b/.github/workflows/shared_build_workflow.yml
@@ -31,8 +31,8 @@ jobs:
 
       - name: Install Apache Jena
         run: |
-          wget https://dlcdn.apache.org/jena/binaries/apache-jena-5.2.0.tar.gz
-          tar -xzf apache-jena-5.2.0.tar.gz
+          wget https://dlcdn.apache.org/jena/binaries/apache-jena-5.3.0.tar.gz
+          tar -xzf apache-jena-5.3.0.tar.gz
 
       - name: Download external test files
         run: |
@@ -40,7 +40,7 @@ jobs:
           "curl -o test/Api.Tests/TestData/imf.ttl http://ns.imfid.org/20240531/imf-ontology.owl.ttl" 
           "curl -o test/Api.Tests/TestData/go.owl.xml http://current.geneontology.org/ontology/go.owl"
           "curl -o test/Api.Tests/TestData/LIS-14.ttl https://rds.posccaesar.org/ontology/lis14/ont/core/4.0/LIS-14.ttl"
-          ./apache-jena-5.2.0/bin/riot --output=TURTLE test/Api.Tests/TestData/go.owl.xml > test/Api.Tests/TestData/go.ttl
+          ./apache-jena-5.3.0/bin/riot --output=TURTLE test/Api.Tests/TestData/go.owl.xml > test/Api.Tests/TestData/go.ttl
 
       - name: Format code
         run: dotnet format ./DagSemTools.sln --verbosity diagnostic --verify-no-changes --no-restore

--- a/src/Api/Graph.cs
+++ b/src/Api/Graph.cs
@@ -188,7 +188,7 @@ public class Graph : IGraph
     /// <inheritdoc />
     public void EnableOwlReasoning()
     {
-        var ontology = new DagSemTools.RdfOwlTranslator.Rdf2Owl(Triples.Triples, Triples.Resources).extractOntology;
+        var ontology = new DagSemTools.RdfOwlTranslator.Rdf2Owl(Triples.Triples, Triples.Resources, _logger).extractOntology;
         var ontologyRules = DagSemTools.OWL2RL2Datalog.Library.owl2Datalog(_logger, Triples.Resources, ontology);
         LoadDatalog(ontologyRules);
     }

--- a/src/Api/OwlOntology.cs
+++ b/src/Api/OwlOntology.cs
@@ -30,7 +30,7 @@ public class OwlOntology
             .WriteTo.Console()
             .CreateLogger();
         _datastore = graph.Datastore;
-        var translator = new Rdf2Owl(_datastore.Triples, _datastore.Resources);
+        var translator = new Rdf2Owl(_datastore.Triples, _datastore.Resources, _logger);
         _owlOntology = translator.extractOntology;
     }
 

--- a/src/Datalog.Parser/PredicateVisitor.cs
+++ b/src/Datalog.Parser/PredicateVisitor.cs
@@ -14,7 +14,7 @@ using DagSemTools.Datalog.Parser;
 using static DatalogParser;
 
 /// <inheritdoc />
-internal class PredicateVisitor : DatalogBaseVisitor<ResourceOrVariable>
+internal class PredicateVisitor : DatalogBaseVisitor<Term>
 {
     internal ResourceVisitor ResourceVisitor { get; }
 
@@ -25,10 +25,10 @@ internal class PredicateVisitor : DatalogBaseVisitor<ResourceOrVariable>
     }
 
     /// <inheritdoc />
-    public override ResourceOrVariable VisitPredicateVerb(DatalogParser.PredicateVerbContext context)
+    public override Term VisitPredicateVerb(DatalogParser.PredicateVerbContext context)
     {
         var resource = ResourceVisitor.Visit(context);
-        return ResourceOrVariable.NewResource(resource);
+        return Term.NewResource(resource);
     }
 
 
@@ -37,19 +37,19 @@ internal class PredicateVisitor : DatalogBaseVisitor<ResourceOrVariable>
     /// </summary>
     /// <param name="context"></param>
     /// <returns></returns>
-    public override ResourceOrVariable VisitRdfTypeAbbrVerb(RdfTypeAbbrVerbContext context) =>
-        ResourceOrVariable.NewResource(ResourceVisitor.Visit(context));
+    public override Term VisitRdfTypeAbbrVerb(RdfTypeAbbrVerbContext context) =>
+        Term.NewResource(ResourceVisitor.Visit(context));
 
 
     /// <inheritdoc />
-    public override ResourceOrVariable VisitRdfobject(DatalogParser.RdfobjectContext context)
+    public override Term VisitRdfobject(DatalogParser.RdfobjectContext context)
     {
-        return ResourceOrVariable.NewResource(ResourceVisitor.Visit(context));
+        return Term.NewResource(ResourceVisitor.Visit(context));
     }
 
     /// <inheritdoc />
-    public override ResourceOrVariable VisitVariable(DatalogParser.VariableContext context)
+    public override Term VisitVariable(DatalogParser.VariableContext context)
     {
-        return ResourceOrVariable.NewVariable(context.GetText());
+        return Term.NewVariable(context.GetText());
     }
 }

--- a/src/Datalog.Parser/TriplePatternVisitor.cs
+++ b/src/Datalog.Parser/TriplePatternVisitor.cs
@@ -45,7 +45,7 @@ internal class TriplePatternVisitor : DatalogBaseVisitor<TriplePattern>
     public override TriplePattern VisitTypeAtom(DatalogParser.TypeAtomContext context)
     {
         var subject = context.term();
-        var predicate = ResourceOrVariable
+        var predicate = Term
             .NewResource(_predicateVisitor.ResourceVisitor.Datastore
                 .AddNodeResource(RdfResource
                     .NewIri(new IriReference(Namespaces.RdfType))));

--- a/src/Datalog/PredicateGrounder.fs
+++ b/src/Datalog/PredicateGrounder.fs
@@ -19,7 +19,7 @@ module PredicateGrounder =
     let getTriplePredicate (triple: TriplePattern)  =
         match triple.Predicate with
         | Variable _ -> None
-        | ResourceOrVariable.Resource r -> Some r
+        | Term.Resource r -> Some r
 
     let getRuleHeadPredicate (head : RuleHead) =
         match head with
@@ -34,19 +34,19 @@ module PredicateGrounder =
         let dataPredicates = triplestore.Resources.GetIriResourceIds()
         Seq. concat [headPredicates; dataPredicates] |> Seq.distinct
 
-    let instantiateTripleWithVariableMapping (triple : TriplePattern) (variableName : ResourceOrVariable) predicate : TriplePattern =
+    let instantiateTripleWithVariableMapping (triple : TriplePattern) (variableName : Term) predicate : TriplePattern =
         let tripleList =
             [triple.Subject; triple.Predicate; triple.Object]
             |> List.map (fun res -> 
             match res with
-                    | _variableName when _variableName = variableName -> ResourceOrVariable.Resource predicate
+                    | _variableName when _variableName = variableName -> Term.Resource predicate
                     | _ -> res)
         {Subject = tripleList.[0]; Predicate = tripleList.[1]; Object = tripleList.[2]}
         
     let instantiateRuleWithVariableMapping (predicate, rule: Rule, variableName) =
         let newHead = match rule.Head with
                         | Contradiction -> Contradiction
-                        | NormalHead triplePattern -> NormalHead {triplePattern with Predicate = ResourceOrVariable.Resource predicate}
+                        | NormalHead triplePattern -> NormalHead {triplePattern with Predicate = Term.Resource predicate}
         let newBody = rule.Body |> List.map (
             fun atom ->
                 match atom with
@@ -62,12 +62,12 @@ module PredicateGrounder =
                         match ruleHead.Predicate with
                         | Variable s -> predicates
                                         |> Seq.map (fun p -> instantiateRuleWithVariableMapping(p, rule, Variable s))
-                        | ResourceOrVariable.Resource _ -> [rule]
+                        | Term.Resource _ -> [rule]
 
     let getTripleRelationVariable (triple : TriplePattern) =
         match triple.Predicate with
         | Variable s -> Some s
-        | ResourceOrVariable.Resource _ -> None
+        | Term.Resource _ -> None
         
     let getBodyRelationVariables (rule: Rule) =
         rule.Body |> List.choose (fun atom ->

--- a/src/Datalog/Reasoner.fs
+++ b/src/Datalog/Reasoner.fs
@@ -79,7 +79,7 @@ module Reasoner =
 
     let evaluate (logger: ILogger, rules: Rule list, triplestore: Datastore) =
             // let rules_with_iri_predicates = PredicateGrounder.groundRulePredicates(rules, triplestore) |> Seq.toList
-            let stratifier = RulePartitioner (logger, rules)
+            let stratifier = RulePartitioner (logger, rules, triplestore.Resources)
             let stratification = stratifier.orderRules
             for partition in stratification do
                 let program = DatalogProgram(Rules = Seq.toList partition, tripleStore = triplestore)

--- a/src/Datalog/Stratifier.fs
+++ b/src/Datalog/Stratifier.fs
@@ -39,10 +39,10 @@ module Stratifier =
         match relation with
         | AllRelations -> true
         | BinaryPredicate res -> match triple.Predicate with
-                                    | ResourceOrVariable.Resource res' -> res = res'
+                                    | Term.Resource res' -> res = res'
                                     | _ -> false
         | UnaryPredicate (res, obj) -> match triple.Predicate, triple.Object with
-                                        | ResourceOrVariable.Resource res', ResourceOrVariable.Resource obj' -> res = res' && obj = obj'
+                                        | Term.Resource res', Term.Resource obj' -> res = res' && obj = obj'
                                         | _ -> false
         
     let MatchRelations (rel1) (rel2) : bool =
@@ -75,10 +75,10 @@ module Stratifier =
     }
     let GetTriplePatternRelation (triple : TriplePattern) : Relation =
             match triple.Predicate with
-                                        | ResourceOrVariable.Variable _ -> AllRelations
-                                        | ResourceOrVariable.Resource res -> match triple.Object with
-                                                                                    | ResourceOrVariable.Variable _ -> (BinaryPredicate res)
-                                                                                    | ResourceOrVariable.Resource obj -> (UnaryPredicate (res, obj))
+                                        | Term.Variable _ -> AllRelations
+                                        | Term.Resource res -> match triple.Object with
+                                                                                    | Term.Variable _ -> (BinaryPredicate res)
+                                                                                    | Term.Resource obj -> (UnaryPredicate (res, obj))
     let GetRuleHeadRelation (triple : RuleHead) : Relation option =
             match triple with
             | Contradiction  -> None
@@ -340,7 +340,7 @@ module Stratifier =
         member this.is_stratified (stratification: Rule seq seq) =
             ready_elements_queue.Count = 0
             && next_elements_queue.Count = 0
-            && (stratification |> Seq.sumBy Seq.length) >= rules.Length
+            // && (stratification |> Seq.sumBy Seq.length) >= rules.Length
             // && ordered_relations |> Array.forall (fun relation -> relation.intensional = false)
 
         (* Used in the while loop in orderRules to test whether stratification is finished *)

--- a/src/Datalog/Stratifier.fs
+++ b/src/Datalog/Stratifier.fs
@@ -58,8 +58,8 @@ module Stratifier =
     [<StructuralEquality>]
     [<StructuralComparison>]
     type RelationEdge =
-        | PositiveRelationEdge of pedge:  int
-        | NegativeRelationEdge of nedge: int
+        | PositiveRelationEdge of pedge: uint
+        | NegativeRelationEdge of nedge: uint
     
     [<Struct>]
     [<StructuralEquality>]
@@ -137,10 +137,10 @@ module Stratifier =
         NegativeIntentionalProperties rules |> Seq.isEmpty
   
     (* The RulePartitioner creates a stratification of the program if it is stratifiable, and otherwise fails *)
-    type RulePartitioner (logger: ILogger, rules: Rule list) =
+    type RulePartitioner (logger: ILogger, rules: Rule list, resources: DagSemTools.Rdf.GraphElementManager) =
         
         let relations = GetRelations rules |> Seq.toArray
-        let relationMap = relations |> Array.mapi (fun i r -> r, i) |> Map.ofArray
+        let relationMap  = relations |> Array.mapi (fun i r -> r, (uint i)) |> Map.ofArray
         
         (* 
             This is the core of a topoogical sorting of the relations.
@@ -152,7 +152,7 @@ module Stratifier =
             This method is called whenever a relation is removed from the queue of relations ready for ouput
             
         *)
-        let updateAtom (_ordered : OrderedRelation array) relationEdgeType (headRelationNo : int) (bodyTriplePattern : TriplePattern) =
+        let updateAtom (_ordered : OrderedRelation array) relationEdgeType (headRelationNo : uint) (bodyTriplePattern : TriplePattern) =
             let atomRelation = bodyTriplePattern |> GetTriplePatternRelation
             let numRelations = Array.length _ordered
             let atomRelationNo = relationMap.[atomRelation]
@@ -165,12 +165,12 @@ module Stratifier =
             | false, _ -> ()
             | true, wildcardRelationNo ->
                 for i in 0 .. (Array.length _ordered - 1) do
-                    if i <> wildcardRelationNo then
-                        _ordered.[i].Successors <- PositiveRelationEdge wildcardRelationNo :: _ordered.[i].Successors
-                        _ordered.[wildcardRelationNo].num_predecessors <- _ordered.[wildcardRelationNo].num_predecessors + 1u
+                    if (uint i) <> wildcardRelationNo then
+                        _ordered.[i].Successors <- PositiveRelationEdge (uint wildcardRelationNo) :: _ordered.[i].Successors
+                        _ordered.[int wildcardRelationNo].num_predecessors <- _ordered.[int wildcardRelationNo].num_predecessors + 1u
             _ordered
                     
-        let updateRelation (_ordered : OrderedRelation array) (headRelationNo : int) (ruleBodyAtom : RuleAtom) =
+        let updateRelation (_ordered : OrderedRelation array) (headRelationNo : uint) (ruleBodyAtom : RuleAtom) =
                 _ordered.[int headRelationNo].intensional <- true
                 match ruleBodyAtom with
                 | NotTriple t ->
@@ -200,23 +200,23 @@ module Stratifier =
         
         (* The queue contains all relations that are not dependent on any relations (that have not already been output) *)
         let mutable ready_elements_queue =
-            Queue<int>(ordered_relations |> Array.filter (fun concept -> concept.num_predecessors = 0u)
+            Queue<uint>(ordered_relations |> Array.filter (fun concept -> concept.num_predecessors = 0u)
                     |> Array.map (fun concept -> relationMap.[concept.Relation]))
             
         (* The concepts that depended on a negation of a concept that is being output in the current stratification must wait till the next layer *)
-        let mutable next_elements_queue = Queue<int>()
+        let mutable next_elements_queue = Queue<uint>()
         let mutable n_unordered = Array.length ordered_relations - ready_elements_queue.Count
         
         let printCycle cycle =
             cycle
-            |> Seq.map (fun n -> $"Cycle element: %i{n}")
+            |> Seq.map (fun n -> $"Cycle element: {resources.GetGraphElement n}")
             |> String.concat ", "
                 
                 
         
         (* Called when the topological sorting cannot proceed, hence assuming the existence of a cycle *)
-        member this.cycle_finder (visited : int seq) (current : int) : int seq seq =
-            let current_element = ordered_relations.[current]
+        member this.cycle_finder (visited : uint seq) (current : uint) : uint seq seq =
+            let current_element = ordered_relations.[int current]
             if (visited |> Seq.contains current) then
                 visited |> Seq.skipWhile (fun id -> id <> current) |> Seq.distinct |> Seq.singleton
             else if current_element.visited then Seq.empty
@@ -253,24 +253,24 @@ module Stratifier =
             
             
         (* Updates a successor of a relation, and if the relation is ready to be output, it is added to the queue *)
-        member this.update_successor (removed_relation_id : int) (successor : RelationEdge) =
+        member this.update_successor (removed_relation_id : uint) (successor : RelationEdge) =
             let relation_id = 
                 match successor with
                 | PositiveRelationEdge relation_id ->
                     relation_id
                 | NegativeRelationEdge relation_id ->
-                    let removed_relation = ordered_relations.[removed_relation_id]
+                    let removed_relation = ordered_relations.[int removed_relation_id]
                     if removed_relation.intensional then
-                        ordered_relations.[relation_id].uses_intensional_negative_edge <- true
+                        ordered_relations.[int relation_id].uses_intensional_negative_edge <- true
                     relation_id
-            let old_relation = ordered_relations.[relation_id]
+            let old_relation = ordered_relations.[int relation_id]
             if not old_relation.output then        
                 if old_relation.num_predecessors < 1u then failwith "Datalog program preprocessing failed. This is a bug, please report that topological ordering failed, num_predecessors < 1"
                 let new_predecessors = old_relation.num_predecessors - 1u
-                ordered_relations.[relation_id] <- { old_relation with num_predecessors = new_predecessors }
-                if ordered_relations.[relation_id].num_predecessors = 0u && not ordered_relations.[relation_id].output then
-                    ordered_relations.[relation_id].output <- true
-                    if ordered_relations.[relation_id].uses_intensional_negative_edge then
+                ordered_relations.[int relation_id] <- { old_relation with num_predecessors = new_predecessors }
+                if ordered_relations.[int relation_id].num_predecessors = 0u && not ordered_relations.[int relation_id].output then
+                    ordered_relations.[int relation_id].output <- true
+                    if ordered_relations.[int relation_id].uses_intensional_negative_edge then
                         next_elements_queue.Enqueue(relation_id)
                     else
                         ready_elements_queue.Enqueue(relation_id)
@@ -283,7 +283,7 @@ module Stratifier =
             let mutable ordered_rules = Seq.empty
             while ready_elements_queue.Count > 0 do
                 let relation_id = ready_elements_queue.Dequeue()
-                let relation = relations.[relation_id]    
+                let relation = relations.[int relation_id]    
                 ordered_relations.[int relation_id].Successors |> Seq.iter (this.update_successor relation_id)
                 // if ordered_relations.[relation_id].intensional then
                 let relation_rules = rules
@@ -299,7 +299,7 @@ module Stratifier =
         member this.RuleIsCoveredByCycle cycle rule =
                 rule.Body |> Seq.forall (fun atom ->
                                             let atomRelation = atom|> GetRuleAtomRelation 
-                                            ordered_relations.[relationMap.[atomRelation]].intensional = false
+                                            ordered_relations.[int relationMap.[atomRelation]].intensional = false
                                             || (cycle |> Seq.exists (MatchRelations atomRelation))
                                         )
         (* 
@@ -320,16 +320,16 @@ module Stratifier =
                             let cycle_element = cycle |> Seq.head
                             let rules = rules
                                         |> List.filter (fun rule ->
-                                            (rule.Head |> GetRuleHeadRelation) = Some relations.[cycle_element]
+                                            (rule.Head |> GetRuleHeadRelation) = Some relations.[int cycle_element]
                                             )
-                            rules |> List.forall (this.RuleIsCoveredByCycle (cycle |> Seq.map (fun id -> relations.[id])))
+                            rules |> List.forall (this.RuleIsCoveredByCycle (cycle |> Seq.map (fun id -> relations.[int id])))
                             )
                             
                   )
             cycles |> Seq.iter (fun cycle ->
                   cycle |> Seq.distinct |>(Seq.iter (fun rel ->
-                      if not ordered_relations.[rel].output then 
-                        ordered_relations.[rel].output <- true
+                      if not ordered_relations.[int rel].output then 
+                        ordered_relations.[int rel].output <- true
                         ready_elements_queue.Enqueue rel)
                   ))
                 

--- a/src/ELI/ELI2RL.fs
+++ b/src/ELI/ELI2RL.fs
@@ -21,28 +21,28 @@ open Serilog
 module ELI2RL =
 
     let internal GetTypeTriplePattern (resources: GraphElementManager) varName className =
-        { TriplePattern.Subject = ResourceOrVariable.Variable varName
-          Predicate = ResourceOrVariable.Resource(resources.AddNodeResource(Iri(IriReference Namespaces.RdfType)))
-          Object = ResourceOrVariable.Resource (resources.AddNodeResource(Iri className)) }
+        { TriplePattern.Subject = Term.Variable varName
+          Predicate = Term.Resource(resources.AddNodeResource(Iri(IriReference Namespaces.RdfType)))
+          Object = Term.Resource (resources.AddNodeResource(Iri className)) }
 
     
     let internal GetAnonymousTypeTriplePattern (resources: GraphElementManager) varName=
-        { TriplePattern.Subject = ResourceOrVariable.Variable varName
-          Predicate = ResourceOrVariable.Resource(resources.AddNodeResource(Iri(IriReference Namespaces.RdfType)))
-          Object = ResourceOrVariable.Resource (resources.CreateUnnamedAnonResource()) }
+        { TriplePattern.Subject = Term.Variable varName
+          Predicate = Term.Resource(resources.AddNodeResource(Iri(IriReference Namespaces.RdfType)))
+          Object = Term.Resource (resources.CreateUnnamedAnonResource()) }
     
     let internal GetRoleTriplePattern (resources: GraphElementManager) role subjectVar objectVar =
-        { TriplePattern.Subject = ResourceOrVariable.Variable subjectVar
-          Predicate = (ResourceOrVariable.Resource role)
-          Object = ResourceOrVariable.Variable objectVar }
+        { TriplePattern.Subject = Term.Variable subjectVar
+          Predicate = (Term.Resource role)
+          Object = Term.Variable objectVar }
 
     let internal GetRoleValueTriplePattern (resources: GraphElementManager) role subjectVar (objectValue : Individual) =
         let obj = match objectValue with
                     | NamedIndividual (FullIri name) -> resources.AddNodeResource(Iri name) 
                     | AnonymousIndividual anonId -> resources.GetOrCreateNamedAnonResource($"{anonId}")
-        { TriplePattern.Subject = ResourceOrVariable.Variable subjectVar
-          Predicate = (ResourceOrVariable.Resource role)
-          Object = ResourceOrVariable.Resource obj }
+        { TriplePattern.Subject = Term.Variable subjectVar
+          Predicate = (Term.Resource role)
+          Object = Term.Resource obj }
 
     
     (* 

--- a/src/Ingress/GraphElement.fs
+++ b/src/Ingress/GraphElement.fs
@@ -19,7 +19,7 @@ open IriTools
         | AnonymousBlankNode of anon_blankNode: uint32
         override this.ToString() =
                 match this with
-                | Iri iri -> $"<(%A{iri})>"
+                | Iri iri -> $"<%A{iri}>"
                 | AnonymousBlankNode anon_blankNode -> $"_:(%u{anon_blankNode})"
             
     [<StructuralComparison>]

--- a/src/OWL2RL2Datalog/Equality.fs
+++ b/src/OWL2RL2Datalog/Equality.fs
@@ -18,28 +18,28 @@ module Equality =
 
     let internal GetSymmetryAxiom (resources : GraphElementManager) =
         let owlSameAs = (resources.AddNodeResource( Iri(new IriReference (Namespaces.OwlSameAs))))
-        { Head = NormalHead ({Subject = ResourceOrVariable.Variable "x"
-                              Predicate = ResourceOrVariable.Resource owlSameAs
-                              Object = ResourceOrVariable.Variable "y"
+        { Head = NormalHead ({Subject = Term.Variable "x"
+                              Predicate = Term.Resource owlSameAs
+                              Object = Term.Variable "y"
                             })
-          Body =  [PositiveTriple ({Subject = ResourceOrVariable.Variable "y"
-                                    Predicate = ResourceOrVariable.Resource owlSameAs
-                                    Object = ResourceOrVariable.Variable "x"
+          Body =  [PositiveTriple ({Subject = Term.Variable "y"
+                                    Predicate = Term.Resource owlSameAs
+                                    Object = Term.Variable "x"
                      })]}
     
     let internal GetTransitivityAxiom (resources : GraphElementManager) =
         let owlSameAs = (resources.AddNodeResource( Iri(new IriReference (Namespaces.OwlSameAs))))
-        { Head = NormalHead ({Subject = ResourceOrVariable.Variable "x"
-                              Predicate = ResourceOrVariable.Resource owlSameAs
-                              Object = ResourceOrVariable.Variable "z"
+        { Head = NormalHead ({Subject = Term.Variable "x"
+                              Predicate = Term.Resource owlSameAs
+                              Object = Term.Variable "z"
                             })
-          Body =  [PositiveTriple ({Subject = ResourceOrVariable.Variable "x"
-                                    Predicate = ResourceOrVariable.Resource owlSameAs
-                                    Object = ResourceOrVariable.Variable "y"
+          Body =  [PositiveTriple ({Subject = Term.Variable "x"
+                                    Predicate = Term.Resource owlSameAs
+                                    Object = Term.Variable "y"
                      });
-                     PositiveTriple ({Subject = ResourceOrVariable.Variable "y"
-                                                Predicate = ResourceOrVariable.Resource owlSameAs
-                                                Object = ResourceOrVariable.Variable "z"
+                     PositiveTriple ({Subject = Term.Variable "y"
+                                                Predicate = Term.Resource owlSameAs
+                                                Object = Term.Variable "z"
                                  })
           
           ]
@@ -48,33 +48,33 @@ module Equality =
         
     let internal GetSubjectEqualityAxiom (resources : GraphElementManager) =
         let owlSameAs = (resources.AddNodeResource( Iri(new IriReference (Namespaces.OwlSameAs))))
-        { Head = NormalHead ({Subject = ResourceOrVariable.Variable "s2"
-                              Predicate = ResourceOrVariable.Variable "p"
-                              Object = ResourceOrVariable.Variable "o"
+        { Head = NormalHead ({Subject = Term.Variable "s2"
+                              Predicate = Term.Variable "p"
+                              Object = Term.Variable "o"
                             })
-          Body =  [PositiveTriple ({Subject = ResourceOrVariable.Variable "s1"
-                                    Predicate = ResourceOrVariable.Resource owlSameAs
-                                    Object = ResourceOrVariable.Variable "s2"
+          Body =  [PositiveTriple ({Subject = Term.Variable "s1"
+                                    Predicate = Term.Resource owlSameAs
+                                    Object = Term.Variable "s2"
                      }) ;
-                    PositiveTriple {Subject = ResourceOrVariable.Variable "s1"
-                                    Predicate = ResourceOrVariable.Variable "p"
-                                    Object = ResourceOrVariable.Variable "o"
+                    PositiveTriple {Subject = Term.Variable "s1"
+                                    Predicate = Term.Variable "p"
+                                    Object = Term.Variable "o"
                             }
                 ]
           }
     let internal GetObjectEqualityAxiom (resources : GraphElementManager) =
         let owlSameAs = (resources.AddNodeResource( Iri(new IriReference (Namespaces.OwlSameAs))))
-        { Head = NormalHead ({Subject = ResourceOrVariable.Variable "s"
-                              Predicate = ResourceOrVariable.Variable "p"
-                              Object = ResourceOrVariable.Variable "o2"
+        { Head = NormalHead ({Subject = Term.Variable "s"
+                              Predicate = Term.Variable "p"
+                              Object = Term.Variable "o2"
                             })
-          Body =  [PositiveTriple ({Subject = ResourceOrVariable.Variable "o1"
-                                    Predicate = ResourceOrVariable.Resource owlSameAs
-                                    Object = ResourceOrVariable.Variable "o2"
+          Body =  [PositiveTriple ({Subject = Term.Variable "o1"
+                                    Predicate = Term.Resource owlSameAs
+                                    Object = Term.Variable "o2"
                      }) ;
-                    PositiveTriple {Subject = ResourceOrVariable.Variable "s"
-                                    Predicate = ResourceOrVariable.Variable "p"
-                                    Object = ResourceOrVariable.Variable "o1"
+                    PositiveTriple {Subject = Term.Variable "s"
+                                    Predicate = Term.Variable "p"
+                                    Object = Term.Variable "o1"
                             }
                 ]
           }

--- a/src/OWL2RL2Datalog/Library.fs
+++ b/src/OWL2RL2Datalog/Library.fs
@@ -49,14 +49,14 @@ module Library =
         let domainClassResource = getClassExpressionResource resources domExp
 
         [ { Rule.Head = NormalHead
-              { TriplePattern.Subject = ResourceOrVariable.Variable "x"
-                TriplePattern.Predicate = ResourceOrVariable.Resource resourceMap.[Namespaces.RdfType]
-                TriplePattern.Object = ResourceOrVariable.Resource domainClassResource }
+              { TriplePattern.Subject = Term.Variable "x"
+                TriplePattern.Predicate = Term.Resource resourceMap.[Namespaces.RdfType]
+                TriplePattern.Object = Term.Resource domainClassResource }
             Rule.Body =
               [ (RuleAtom.PositiveTriple
-                    { Subject = ResourceOrVariable.Variable "x"
-                      Predicate = ResourceOrVariable.Resource propertyResource
-                      Object = ResourceOrVariable.Variable "y" }) ] } ]
+                    { Subject = Term.Variable "x"
+                      Predicate = Term.Resource propertyResource
+                      Object = Term.Variable "y" }) ] } ]
 
 
 
@@ -70,14 +70,14 @@ module Library =
         let rangeClassResource = getClassExpressionResource resources rangeExp
 
         [ { Rule.Head = NormalHead
-              { TriplePattern.Subject = ResourceOrVariable.Variable "y"
-                TriplePattern.Predicate = ResourceOrVariable.Resource resourceMap.[Namespaces.RdfType]
-                TriplePattern.Object = ResourceOrVariable.Resource rangeClassResource }
+              { TriplePattern.Subject = Term.Variable "y"
+                TriplePattern.Predicate = Term.Resource resourceMap.[Namespaces.RdfType]
+                TriplePattern.Object = Term.Resource rangeClassResource }
             Rule.Body =
               [ (RuleAtom.PositiveTriple
-                    { Subject = ResourceOrVariable.Variable "x"
-                      Predicate = ResourceOrVariable.Resource propertyResource
-                      Object = ResourceOrVariable.Variable "y" }) ] } ]
+                    { Subject = Term.Variable "x"
+                      Predicate = Term.Resource propertyResource
+                      Object = Term.Variable "y" }) ] } ]
     (* prp-symp 	T(?p, rdf:type, owl:SymmetricProperty) T(?x, ?p, ?y) ->	T(?y, ?p, ?x)  *)
     let SymmetricObjectProperty2Datalog
         (resourceMap: Map<string, Ingress.GraphElementId>)
@@ -87,14 +87,14 @@ module Library =
         let propertyResource = getObjectPropertyExpressionResource resources objProp
 
         [ { Rule.Head = NormalHead
-              { TriplePattern.Subject = ResourceOrVariable.Variable "y"
-                TriplePattern.Predicate = ResourceOrVariable.Resource propertyResource
-                TriplePattern.Object = ResourceOrVariable.Variable "x" }
+              { TriplePattern.Subject = Term.Variable "y"
+                TriplePattern.Predicate = Term.Resource propertyResource
+                TriplePattern.Object = Term.Variable "x" }
             Rule.Body =
               [ (RuleAtom.PositiveTriple
-                    { Subject = ResourceOrVariable.Variable "x"
-                      Predicate = ResourceOrVariable.Resource propertyResource
-                      Object = ResourceOrVariable.Variable "y" }) ] } ]
+                    { Subject = Term.Variable "x"
+                      Predicate = Term.Resource propertyResource
+                      Object = Term.Variable "y" }) ] } ]
 
 
 

--- a/src/Rdf/Ingress.fs
+++ b/src/Rdf/Ingress.fs
@@ -10,7 +10,7 @@ namespace DagSemTools.Rdf
 open DagSemTools.Ingress
 
 module Ingress =
-    type GraphElementId = uint32
+    type public GraphElementId = uint32
     type TripleListIndex = uint
     type QuadListIndex = uint
         

--- a/src/RdfOwlTranslator/ClassExpressionParser.fs
+++ b/src/RdfOwlTranslator/ClassExpressionParser.fs
@@ -14,6 +14,7 @@ open DagSemTools.Ingress
 open DagSemTools.Ingress.Namespaces
 open DagSemTools.OwlOntology
 open IriTools
+open Serilog
 
 
 (* These functions correspond to table 13 in https://www.w3.org/TR/owl2-mapping-to-rdf/#Parsing_of_Axioms 
@@ -21,46 +22,47 @@ open IriTools
     This table / function only handles anonymous nodes/blank IRIs
 *)
 type ClassExpressionParser (triples : TripleTable,
-              resourceManager : GraphElementManager) =
+              resourceManager : GraphElementManager,
+              logger : ILogger) =
 
     let tripleTable = triples
     let resources = resourceManager
 
-    let rdfTypeId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.RdfType)))
-    let owlOntologyId = resources.AddNodeResource(RdfResource.Iri(new IriReference(Namespaces.OwlOntology)))
-    let versionPropId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.OwlVersionIri)))
-    let importsPropId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.OwlImport)))
-    let owlClassId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.OwlClass)))
-    let owlRestrictionId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.OwlRestriction)))
-    let owlOnPropertyId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.OwlOnProperty)))
-    let owlOnPropertiesId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.OwlOnProperties)))
-    let owlSomeValueFromId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.OwlSomeValuesFrom)))
-    let owlAllValuesFromId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.OwlAllValuesFrom)))
-    let owlIntersectionOfId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.OwlIntersectionOf)))
-    let owlUnionOfId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.OwlUnionOf)))
-    let owlComplementOfId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.OwlComplementOf)))
-    let owlOneOfId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.OwlOneOf)))
-    let owlHasValueId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.OwlHasValue)))
-    let owlHasSelfId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.OwlHasSelf)))
-    let owlOnClassId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.OwlOnClass)))
+    let rdfTypeId = resources.AddNodeResource(RdfResource.Iri (new IriReference(RdfType)))
+    let owlOntologyId = resources.AddNodeResource(RdfResource.Iri(new IriReference(OwlOntology)))
+    let versionPropId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlVersionIri)))
+    let importsPropId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlImport)))
+    let owlClassId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlClass)))
+    let owlRestrictionId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlRestriction)))
+    let owlOnPropertyId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlOnProperty)))
+    let owlOnPropertiesId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlOnProperties)))
+    let owlSomeValueFromId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlSomeValuesFrom)))
+    let owlAllValuesFromId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlAllValuesFrom)))
+    let owlIntersectionOfId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlIntersectionOf)))
+    let owlUnionOfId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlUnionOf)))
+    let owlComplementOfId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlComplementOf)))
+    let owlOneOfId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlOneOf)))
+    let owlHasValueId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlHasValue)))
+    let owlHasSelfId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlHasSelf)))
+    let owlOnClassId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlOnClass)))
     
-    let owlOnDataRangeId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.OwlOnDataRange)))
-    let owlQualifiedCardinalityId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.OwlQualifiedCardinality)))
-    let owlMaxQualifiedCardinalityId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.OwlMaxQualifiedCardinality)))
-    let owlMinQualifiedCardinalityId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.OwlMinQualifiedCardinality)))
-    let owlMaxCardinalityId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.OwlMaxCardinality)))
-    let owlMinCardinalityId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.OwlMinCardinality)))
-    let owlCardinalityId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.OwlCardinality)))
-    let owlAxiomId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.OwlAxiom)))
-    let owlMembersId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.OwlMembers)))
-    let owlAnnPropId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.OwlAnnotatedProperty)))
-    let owlAnnSourceId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.OwlAnnotatedSource)))
-    let owlAnnTargetId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.OwlAnnotatedTarget)))
-    let owlInvObjPropId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.OwlObjectInverseOf)))
-    let subClassPropId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.RdfsSubClassOf)))
-    let rdfNilId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.RdfNil)))
-    let rdfFirstId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.RdfFirst)))
-    let rdfRestId = resources.AddNodeResource(RdfResource.Iri (new IriReference(Namespaces.RdfRest)))
+    let owlOnDataRangeId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlOnDataRange)))
+    let owlQualifiedCardinalityId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlQualifiedCardinality)))
+    let owlMaxQualifiedCardinalityId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlMaxQualifiedCardinality)))
+    let owlMinQualifiedCardinalityId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlMinQualifiedCardinality)))
+    let owlMaxCardinalityId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlMaxCardinality)))
+    let owlMinCardinalityId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlMinCardinality)))
+    let owlCardinalityId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlCardinality)))
+    let owlAxiomId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlAxiom)))
+    let owlMembersId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlMembers)))
+    let owlAnnPropId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlAnnotatedProperty)))
+    let owlAnnSourceId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlAnnotatedSource)))
+    let owlAnnTargetId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlAnnotatedTarget)))
+    let owlInvObjPropId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlObjectInverseOf)))
+    let subClassPropId = resources.AddNodeResource(RdfResource.Iri (new IriReference(RdfsSubClassOf)))
+    let rdfNilId = resources.AddNodeResource(RdfResource.Iri (new IriReference(RdfNil)))
+    let rdfFirstId = resources.AddNodeResource(RdfResource.Iri (new IriReference(RdfFirst)))
+    let rdfRestId = resources.AddNodeResource(RdfResource.Iri (new IriReference(RdfRest)))
         
     let GetResourceInfoForErrorMessage subject : string =
            tripleTable.GetTriplesMentioning subject
@@ -114,7 +116,7 @@ type ClassExpressionParser (triples : TripleTable,
                                                 
     (* CE *)
     let mutable ClassExpressions : Map<GraphElementId, ClassExpression> =
-        let mutable specDeclarations = (getInitialDeclarations Namespaces.OwlClass) |> Seq.map (fun (id, iri) ->  (id, ClassName iri)) |> Map.ofSeq
+        let mutable specDeclarations = (getInitialDeclarations OwlClass) |> Seq.map (fun (id, iri) ->  (id, ClassName iri)) |> Map.ofSeq
         getSubClassClasses
         |> Seq.fold (fun specDecls (classId, classIri) ->
             if not (specDecls.ContainsKey classId) then
@@ -125,12 +127,12 @@ type ClassExpressionParser (triples : TripleTable,
     
     (* DR *)
     let mutable DataRanges : Map<GraphElementId, DataRange> =
-        getInitialDeclarations Namespaces.RdfsDatatype
+        getInitialDeclarations RdfsDatatype
         |> Seq.map (fun (id, iri) ->  (id, NamedDataRange iri))
         |> Map.ofSeq
     (* OPE *)
     let mutable ObjectPropertyExpressions : Map<GraphElementId, ObjectPropertyExpression> =
-        let mutable firstMap = getInitialDeclarations Namespaces.OwlObjectProperty
+        let mutable firstMap = getInitialDeclarations OwlObjectProperty
                             |> Seq.map (fun (id, iri) ->  (id, NamedObjectProperty iri))
         let secondMap = tripleTable.GetTriplesWithPredicate(owlInvObjPropId)
                             |> Seq.choose (fun invTR -> resources.GetNamedResource(invTR.obj) |> Option.map (fun obj -> (invTR.subject, obj)))
@@ -138,18 +140,18 @@ type ClassExpressionParser (triples : TripleTable,
         [firstMap ; secondMap] |> Seq.concat |> Map.ofSeq
     (* DPE *)
     let mutable DataPropertyExpressions : Map<GraphElementId, DataProperty> =
-        getInitialDeclarations Namespaces.OwlDatatypeProperty
+        getInitialDeclarations OwlDatatypeProperty
         |> Seq.map (fun (id, iri) ->  (id, iri))
         |> Map.ofSeq
         
         
     (* AP *)
     let mutable AnnotationProperties : Map<GraphElementId, AnnotationProperty> =
-        getInitialDeclarations Namespaces.OwlAnnotationProperty
+        getInitialDeclarations OwlAnnotationProperty
         |> Seq.map (fun (id, iri) ->  (id, iri))
         |> Map.ofSeq
     let mutable Individuals : Map<GraphElementId, Individual> =
-        getInitialDeclarations Namespaces.OwlNamedIndividual
+        getInitialDeclarations OwlNamedIndividual
         |> Seq.map (fun (id, iri) -> (id, NamedIndividual iri))
         |> Map.ofSeq
     
@@ -261,14 +263,20 @@ type ClassExpressionParser (triples : TripleTable,
         | true, prop -> prop
         | false, _ -> failwith $"Invalid OWL ontology: {resources.GetGraphElement propResourceId} used  as a data range but not declared"
         
-    (* This is aalled when resourceId can be a class or data range *)
-    let tryGetClassOrDataRangeAxiom  resourceId classDeclarer datatypeDeclarer =
-        match (ClassExpressions.TryGetValue resourceId, DataRanges.TryGetValue resourceId) with
-        | ((true, expr), (false, _)) -> classDeclarer expr
-        | ((false, _), (true, expr)) -> match expr with
-                                            | DataRange.NamedDataRange dt -> datatypeDeclarer dt
+    (* This is aalled when resourceId can be a class *)
+    let tryGetClassAxiom  resourceId classDeclarer datatypeDeclarer =
+        match (ClassExpressions.TryGetValue resourceId) with
+        | ((true, expr)) -> classDeclarer expr |> Some
+        | ((false, _)) -> None
+    
+    (* This is aalled when resourceId can be a data range *)
+    let tryGetDataRangeAxiom  resourceId classDeclarer datatypeDeclarer =
+        match (DataRanges.TryGetValue resourceId) with
+        | ((true, expr)) -> match expr with
+                                            | DataRange.NamedDataRange dt -> Some (datatypeDeclarer dt)
                                             | _ -> failwith $"Invalid OWL Ontology. Only datatypes can be defined. {resources.GetGraphElement resourceId} is not a datatype"
-        | _ -> failwith $"Invalid OWL Ontology. {resources.GetGraphElement resourceId} must be declared as either data range or class expression {GetResourceInfoForErrorMessage resourceId}"
+        | _ -> None
+    
                 
     (* These are called whenever setting CE, OPE, DPE, DR and AP
         These cannot be redefined, as this is an error *)
@@ -311,12 +319,11 @@ type ClassExpressionParser (triples : TripleTable,
         match ClassExpressions.TryGetValue propResourceId with
         | true, prop -> false
         | false, _ -> if ((DataRanges.ContainsKey propResourceId)) then 
-                            failwith $"Invalid OWL ontology: Property {resources.GetGraphElement propResourceId} used both as a data range and a class"
-                      else
-                          match (resources.GetResource propResourceId) with
-                          | Some (RdfResource.Iri iri) -> false
-                          | Some (AnonymousBlankNode bn) -> true
-                          | None -> failwith $"Invalid OWL Ontology: {resources.GetGraphElement propResourceId} used as a class"
+                            logger.Warning $"Invalid OWL ontology: Property {resources.GetGraphElement propResourceId} used both as a data range and a class"
+                      match (resources.GetResource propResourceId) with
+                      | Some (RdfResource.Iri iri) -> false
+                      | Some (AnonymousBlankNode bn) -> true
+                      | None -> failwith $"Invalid OWL Ontology: {resources.GetGraphElement propResourceId} used as a class"
     
     
     (* First four rows of Table 13, Class Expressions in https://www.w3.org/TR/owl2-mapping-to-rdf *)        
@@ -329,7 +336,8 @@ type ClassExpressionParser (triples : TripleTable,
                                             |> Seq.choose (fun trs -> trs |> Seq.filter containsOwlAxiom
                                                                         |> fun t -> match t |> Seq.toList with
                                                                                     | [tr] -> Some tr
-                                                                                    | [] ->  failwith $"Probably invalid or pointless construct in ontology: Anonymous class without expression : {GetResourceInfoForErrorMessage ((trs |> Seq.head).subject)} "
+                                                                                    | [] ->  logger.Warning $"Probably invalid or pointless construct in ontology: Anonymous class without expression : {GetResourceInfoForErrorMessage ((trs |> Seq.head).subject)} "
+                                                                                             None
                                                                                     | _ -> failwith $"Invalid owl ontology: Anonymous class expression defined multiple times: {GetResourceInfoForErrorMessage ((trs |> Seq.head).subject)} "
                                                                                     )                                
         anonymousClassTriples
@@ -371,7 +379,7 @@ type ClassExpressionParser (triples : TripleTable,
                             |> Seq.find (fun tr -> tr.predicate = cardinalityId)
                             |> (_.obj)
                             |> resources.GetGraphElement
-                            |> Ingress.tryGetNonNegativeIntegerLiteral
+                            |> tryGetNonNegativeIntegerLiteral
         match n_opt with 
                 | Some nn -> nn                              
                 | None -> failwith $"Invalid OWL cardinality integer constraint"
@@ -504,7 +512,7 @@ type ClassExpressionParser (triples : TripleTable,
                        |> Seq.find (fun tr -> tr.predicate = owlHasSelfId)
                        |> (_.obj)
                        |> resources.GetGraphElement
-                       |> Ingress.tryGetBoolLiteral
+                       |> tryGetBoolLiteral
                        |> Option.get
         if has_self then
             let OPE_y = tryGetObjectPropertyExpressions y
@@ -739,4 +747,5 @@ type ClassExpressionParser (triples : TripleTable,
                         getAnnotations,
                         tryGetAnyPropertyAxiom,
                         tryGetPropertyDeclaration,
-                        tryGetClassOrDataRangeAxiom)
+                        tryGetClassAxiom,
+                        tryGetDataRangeAxiom)

--- a/src/Turtle.Parser/ResourceVisitor.cs
+++ b/src/Turtle.Parser/ResourceVisitor.cs
@@ -43,7 +43,7 @@ internal class ResourceVisitor : TurtleDocBaseVisitor<uint>
     /// <returns></returns>
     public override uint VisitIri(IriContext ctxt)
     {
-        var iri = _iriGrammarVisitor.VisitIri(ctxt) 
+        var iri = _iriGrammarVisitor.VisitIri(ctxt)
                   ?? throw new System.Exception($"Assumed IRI in {ctxt.GetText()} at line {ctxt.exception} is null");
         return GetIriId(iri);
     }

--- a/src/Turtle.Parser/ResourceVisitor.cs
+++ b/src/Turtle.Parser/ResourceVisitor.cs
@@ -43,7 +43,8 @@ internal class ResourceVisitor : TurtleDocBaseVisitor<uint>
     /// <returns></returns>
     public override uint VisitIri(IriContext ctxt)
     {
-        var iri = _iriGrammarVisitor.VisitIri(ctxt) ?? throw new System.Exception("IRI is null");
+        var iri = _iriGrammarVisitor.VisitIri(ctxt) 
+                  ?? throw new System.Exception($"Assumed IRI in {ctxt.GetText()} at line {ctxt.exception} is null");
         return GetIriId(iri);
     }
 

--- a/test/AlcTest/AlcTest.fsproj
+++ b/test/AlcTest/AlcTest.fsproj
@@ -22,6 +22,7 @@
         <PackageReference Include="Faqt" Version="4.4.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
         <PackageReference Include="Serilog" Version="4.2.0" />
+        <PackageReference Include="Serilog.Sinks.InMemory" Version="0.11.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Api.Tests/Api.Tests.csproj
+++ b/test/Api.Tests/Api.Tests.csproj
@@ -121,6 +121,9 @@
       <None Update="TestData\cycle-imf-test.ttl">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>
+      <None Update="TestData\LIS-14.ttl">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
     </ItemGroup>
 
 </Project>

--- a/test/Api.Tests/Api.Tests.csproj
+++ b/test/Api.Tests/Api.Tests.csproj
@@ -118,6 +118,9 @@
       <None Update="TestData\qualifiedCardinalityIntersection.ttl">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
+      <None Update="TestData\cycle-imf-test.ttl">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
     </ItemGroup>
 
 </Project>

--- a/test/Api.Tests/TestApiOntology.cs
+++ b/test/Api.Tests/TestApiOntology.cs
@@ -114,7 +114,7 @@ public class TestApiOntology(ITestOutputHelper output)
         _inMemorySink.LogEvents.Should().HaveCount(0);
     }
 
-    [Fact(Skip = "Not working, github issue: https://github.com/daghovland/DagSemTools/issues/55")]
+    [Fact]
     public void LoadImfOntologyWorks()
     {
         // Arrange

--- a/test/Api.Tests/TestApiOntology.cs
+++ b/test/Api.Tests/TestApiOntology.cs
@@ -133,7 +133,7 @@ public class TestApiOntology(ITestOutputHelper output)
         _inMemorySink.LogEvents.Should().HaveCount(0);
     }
 
-    [Fact]
+    [Fact(Skip = "See https://github.com/daghovland/DagSemTools/issues/61")]
     public void LoadImfOntologyWorks()
     {
         // Arrange
@@ -163,10 +163,27 @@ public class TestApiOntology(ITestOutputHelper output)
         _inMemorySink.LogEvents.Should().HaveCount(0);
     }
 
-
-
-
     [Fact]
+    public void ParseImfOntologyWorks()
+    {
+        // Arrange
+        var ontologyFileInfo = new FileInfo("TestData/imf.ttl");
+        var rdfImf = DagSemTools.Api.TurtleParser.Parse(ontologyFileInfo, outputWriter);
+        
+        // Act
+        var ont = OwlOntology.Create(rdfImf);
+        ont.GetAxioms().Should().NotBeEmpty();
+        var axiomRules = ont.GetAxiomRules().ToList();
+
+        axiomRules.Should().NotBeEmpty();
+
+        _inMemorySink.LogEvents.Should().HaveCount(0);
+    }
+
+
+
+
+    [Fact(Skip="See https://github.com/daghovland/DagSemTools/issues/60")]
     public void LoadIDOOntologyWorks()
     {
         var ontologyFileInfo = new FileInfo("TestData/LIS-14.ttl");

--- a/test/Api.Tests/TestApiOntology.cs
+++ b/test/Api.Tests/TestApiOntology.cs
@@ -164,15 +164,31 @@ public class TestApiOntology(ITestOutputHelper output)
     }
 
 
-    [Fact(Skip = "Takes too long for normal testing. https://github.com/daghovland/DagSemTools/issues/58"), Category("LongRunning")]
-    public void LoadGeneOntologyWorks()
+
+
+    [Fact]
+    public void LoadIDOOntologyWorks()
     {
-        var ontologyFileInfo = new FileInfo("TestData/go.ttl");
+        var ontologyFileInfo = new FileInfo("TestData/LIS-14.ttl");
         var rdf = DagSemTools.Api.TurtleParser.Parse(ontologyFileInfo, outputWriter);
         var ont = OwlOntology.Create(rdf);
         ont.GetAxioms().Should().NotBeEmpty();
         var datalogProgram = ont.GetAxiomRules().ToList();
         datalogProgram.Should().NotBeEmpty();
         rdf.LoadDatalog(datalogProgram);
+    }
+    
+    
+    [Fact(Skip = "Takes too long for normal testing. https://github.com/daghovland/DagSemTools/issues/58"), Category("LongRunning")]
+    public void ParseGeneOntologyWorks()
+    {
+        var ontologyFileInfo = new FileInfo("TestData/go.ttl");
+        var rdf = DagSemTools.Api.TurtleParser.Parse(ontologyFileInfo, outputWriter);
+        rdf.IsEmpty().Should().BeFalse();
+        // var ont = OwlOntology.Create(rdf);
+        // ont.GetAxioms().Should().NotBeEmpty();
+        // var datalogProgram = ont.GetAxiomRules().ToList();
+        // datalogProgram.Should().NotBeEmpty();
+        // rdf.LoadDatalog(datalogProgram);
     }
 }

--- a/test/Api.Tests/TestApiOntology.cs
+++ b/test/Api.Tests/TestApiOntology.cs
@@ -169,7 +169,7 @@ public class TestApiOntology(ITestOutputHelper output)
         // Arrange
         var ontologyFileInfo = new FileInfo("TestData/imf.ttl");
         var rdfImf = DagSemTools.Api.TurtleParser.Parse(ontologyFileInfo, outputWriter);
-        
+
         // Act
         var ont = OwlOntology.Create(rdfImf);
         ont.GetAxioms().Should().NotBeEmpty();
@@ -183,7 +183,7 @@ public class TestApiOntology(ITestOutputHelper output)
 
 
 
-    [Fact(Skip="See https://github.com/daghovland/DagSemTools/issues/60")]
+    [Fact(Skip = "See https://github.com/daghovland/DagSemTools/issues/60")]
     public void LoadIDOOntologyWorks()
     {
         var ontologyFileInfo = new FileInfo("TestData/LIS-14.ttl");
@@ -194,8 +194,8 @@ public class TestApiOntology(ITestOutputHelper output)
         datalogProgram.Should().NotBeEmpty();
         rdf.LoadDatalog(datalogProgram);
     }
-    
-    
+
+
     [Fact(Skip = "Takes too long for normal testing. https://github.com/daghovland/DagSemTools/issues/58"), Category("LongRunning")]
     public void ParseGeneOntologyWorks()
     {

--- a/test/Api.Tests/TestData/cycle-imf-test.ttl
+++ b/test/Api.Tests/TestData/cycle-imf-test.ttl
@@ -1,0 +1,96 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix imf: <http://ns.imfid.org/imf#> .
+@prefix o-owl-rstr: <http://tpl.ottr.xyz/owl/restriction/0.1/> .
+@prefix o-rdfs: <http://tpl.ottr.xyz/rdfs/0.2/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix o-imf-t-o: <http://ns.imfid.org/templates/type/owl/> .
+@prefix o-imf-t-s: <http://ns.imfid.org/templates/type/shacl/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix o-imf: <http://ns.imfid.org/templates/> .
+@prefix ottr: <http://ns.ottr.xyz/0.4/> .
+@prefix o-owl-ma: <http://tpl.ottr.xyz/owl/macro/0.1/> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix o-imf-d: <http://ns.imfid.org/templates/data/> .
+@prefix o-rdf: <http://tpl.ottr.xyz/rdf/0.1/> .
+@prefix pca-plm: <http://rds.posccaesar.org/ontology/plm/rdl/> .
+@prefix pav: <http://purl.org/pav/> .
+@prefix ex: <http://example.com#> .
+@prefix o-owl-dec: <http://tpl.ottr.xyz/owl/declaration/0.1/> .
+@prefix o-owl-ax: <http://tpl.ottr.xyz/owl/axiom/0.1/> .
+@prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+
+imf:Aspect
+    vann:termGroup "aspects" ;
+    a owl:Class ;
+    rdfs:subClassOf imf:Descriptor .
+
+imf:TerminalQualifier
+    vann:termGroup "elements" ;
+    a owl:Class ;
+    rdfs:subClassOf imf:Descriptor .
+
+imf:Attribute
+    vann:termGroup "attributes" ;
+    a owl:Class ;
+    rdfs:subClassOf imf:Descriptor .
+
+imf:AttributeGroup
+    vann:termGroup "attributes" ;
+    a owl:Class ;
+    rdfs:subClassOf imf:Descriptor .
+
+imf:AttributeQualifier
+    vann:termGroup "attributes" ;
+    a owl:Class ;
+    rdfs:subClassOf imf:Descriptor .
+
+imf:Descriptor
+    a owl:Class ;
+    rdfs:subClassOf imf:InformationArtefact .
+
+imf:InformationDomain
+    vann:termGroup "aspects" ;
+    a owl:Class ;
+    rdfs:subClassOf imf:Descriptor .
+
+imf:Interest
+    vann:termGroup "aspects" ;
+    a owl:Class ;
+    rdfs:subClassOf imf:Descriptor .
+
+
+imf:Modality
+    vann:termGroup "aspects" ;
+    a owl:Class ;
+    rdfs:subClassOf imf:Descriptor .
+
+
+imf:TerminalQualifier
+    vann:termGroup "elements" ;
+    a owl:Class ;
+    rdfs:subClassOf imf:Descriptor .
+
+imf:hasCharacteristic
+    vann:termGroup "descriptor" ;
+    a owl:ObjectProperty ;
+    rdfs:domain imf:Descriptor ;
+    rdfs:range imf:Descriptor ;
+    rdfs:subPropertyOf imf:reference .
+
+
+imf:reference
+    vann:termGroup "generic relations" ;
+    a owl:ObjectProperty ;
+    rdfs:range imf:Descriptor .
+
+[]
+    a owl:AllDisjointClasses ;
+    owl:members (imf:Element
+        imf:Descriptor
+        imf:InformationModel
+    ) .

--- a/test/Datalog.Test/PredicateGrounderTests.fs
+++ b/test/Datalog.Test/PredicateGrounderTests.fs
@@ -26,11 +26,11 @@ module PredicateGrounderTests =
         let objdIndex = tripleTable.AddNodeResource(Ingress.RdfResource.Iri(new IriReference "http://example.com/object"))
         let objdIndex2 = tripleTable.AddNodeResource(Ingress.RdfResource.Iri(new IriReference "http://example.com/object2"))
         let triplepattern =  {
-                             TriplePattern.Subject = ResourceOrVariable.Resource subjectIndex
+                             TriplePattern.Subject = Term.Resource subjectIndex
                              TriplePattern.Predicate =  Variable "p"
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex}
+                             TriplePattern.Object = Term.Resource objdIndex}
         let groundRule = PredicateGrounder.instantiateTripleWithVariableMapping triplepattern (Variable "p") predIndex
-        groundRule.Predicate.Should().Be(ResourceOrVariable.Resource predIndex)
+        groundRule.Predicate.Should().Be(Term.Resource predIndex)
 
     [<Fact>]
      let ``Multiplier removes variables from negative triple`` () =
@@ -41,13 +41,13 @@ module PredicateGrounderTests =
             let objdIndex = tripleTable.AddNodeResource(Ingress.RdfResource.Iri(new IriReference "http://example.com/object"))
             let objdIndex2 = tripleTable.AddNodeResource(Ingress.RdfResource.Iri(new IriReference "http://example.com/object2"))
             let triplepattern =  {
-                                 TriplePattern.Subject = ResourceOrVariable.Resource subjectIndex
+                                 TriplePattern.Subject = Term.Resource subjectIndex
                                  TriplePattern.Predicate =  Variable "p"
-                                 TriplePattern.Object = ResourceOrVariable.Resource objdIndex}
+                                 TriplePattern.Object = Term.Resource objdIndex}
             let triplepattern2 = PositiveTriple {
-                             TriplePattern.Subject = ResourceOrVariable.Resource subjectIndex
+                             TriplePattern.Subject = Term.Resource subjectIndex
                              TriplePattern.Predicate =  Variable "p"
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex2
+                             TriplePattern.Object = Term.Resource objdIndex2
                              }
             let rule = {Head =  NormalHead( triplepattern )
                         Body = [triplepattern2]}
@@ -55,7 +55,7 @@ module PredicateGrounderTests =
             let groundRule = PredicateGrounder.instantiateRuleWithVariableMapping (predIndex, rule, (Variable "p"))
             match groundRule.Head with
             | Contradiction -> failwith "bug"
-            | NormalHead headPattern ->  headPattern.Predicate.Should().Be(ResourceOrVariable.Resource predIndex) |> ignore
+            | NormalHead headPattern ->  headPattern.Predicate.Should().Be(Term.Resource predIndex) |> ignore
             groundRule.Body.Should().HaveLength(1) |> ignore
             let pred = groundRule.Body.[0] |> PredicateGrounder.getAtomPredicate |> Option.get
             pred.Should().Be(predIndex)
@@ -69,20 +69,20 @@ module PredicateGrounderTests =
             let objdIndex = tripleTable.AddNodeResource(Ingress.RdfResource.Iri(new IriReference "http://example.com/object"))
             let objdIndex2 = tripleTable.AddNodeResource(Ingress.RdfResource.Iri(new IriReference "http://example.com/object2"))
             let triplepattern =  {
-                                 TriplePattern.Subject = ResourceOrVariable.Resource subjectIndex
+                                 TriplePattern.Subject = Term.Resource subjectIndex
                                  TriplePattern.Predicate =  Variable "p"
-                                 TriplePattern.Object = ResourceOrVariable.Resource objdIndex}
+                                 TriplePattern.Object = Term.Resource objdIndex}
             let triplepattern2 = PositiveTriple {
-                             TriplePattern.Subject = ResourceOrVariable.Resource subjectIndex
+                             TriplePattern.Subject = Term.Resource subjectIndex
                              TriplePattern.Predicate =  Variable "p"
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex2
+                             TriplePattern.Object = Term.Resource objdIndex2
                              }
             let rule = {Head = NormalHead triplepattern; Body = [triplepattern2]}
             
             let groundRule = PredicateGrounder.instantiateRuleWithVariableMapping (predIndex, rule, (Variable "p"))
             match groundRule.Head with
             | Contradiction -> failwith "bug"
-            | NormalHead headPattern ->  headPattern.Predicate.Should().Be(ResourceOrVariable.Resource predIndex) |> ignore
+            | NormalHead headPattern ->  headPattern.Predicate.Should().Be(Term.Resource predIndex) |> ignore
             groundRule.Body.Should().HaveLength(1) |> ignore
             let pred = groundRule.Body.[0] |> PredicateGrounder.getAtomPredicate |> Option.get
             pred.Should().Be(predIndex)
@@ -104,13 +104,13 @@ module PredicateGrounderTests =
                                  }
             tripleTable.AddTriple triple
             let triplepattern =  {
-                                 TriplePattern.Subject = ResourceOrVariable.Resource subjectIndex
+                                 TriplePattern.Subject = Term.Resource subjectIndex
                                  TriplePattern.Predicate =  Variable "p"
-                                 TriplePattern.Object = ResourceOrVariable.Resource objdIndex}
+                                 TriplePattern.Object = Term.Resource objdIndex}
             let triplepattern2 = PositiveTriple {
-                             TriplePattern.Subject = ResourceOrVariable.Resource subjectIndex
+                             TriplePattern.Subject = Term.Resource subjectIndex
                              TriplePattern.Predicate =  Variable "p"
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex2
+                             TriplePattern.Object = Term.Resource objdIndex2
                              }
             let rule = {Head = NormalHead triplepattern; Body = [triplepattern2]}
             
@@ -120,7 +120,7 @@ module PredicateGrounderTests =
                                   |> Seq.choose (fun rule -> match rule.Head with
                                                                 | Contradiction -> None
                                                                 | NormalHead headPattern ->
-                                                                    if headPattern.Predicate = ResourceOrVariable.Resource predIndex then
+                                                                    if headPattern.Predicate = Term.Resource predIndex then
                                                                         Some rule
                                                                     else
                                                                         None)
@@ -138,13 +138,13 @@ module PredicateGrounderTests =
             let objdIndex = tripleTable.AddNodeResource(Ingress.RdfResource.Iri(new IriReference "http://example.com/object"))
             let objdIndex2 = tripleTable.AddNodeResource(Ingress.RdfResource.Iri(new IriReference "http://example.com/object2"))
             let triplepattern =  {
-                                 TriplePattern.Subject = ResourceOrVariable.Resource subjectIndex
+                                 TriplePattern.Subject = Term.Resource subjectIndex
                                  TriplePattern.Predicate =  Variable "p"
-                                 TriplePattern.Object = ResourceOrVariable.Resource objdIndex}
+                                 TriplePattern.Object = Term.Resource objdIndex}
             let triplepattern2 = PositiveTriple {
-                             TriplePattern.Subject = ResourceOrVariable.Resource subjectIndex
+                             TriplePattern.Subject = Term.Resource subjectIndex
                              TriplePattern.Predicate =  Variable "p"
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex2
+                             TriplePattern.Object = Term.Resource objdIndex2
                              }
             let rule = {Head = NormalHead triplepattern; Body = [triplepattern2]}
             
@@ -161,13 +161,13 @@ module PredicateGrounderTests =
             let objdIndex = tripleTable.AddNodeResource(Ingress.RdfResource.Iri(new IriReference "http://example.com/object"))
             let objdIndex2 = tripleTable.AddNodeResource(Ingress.RdfResource.Iri(new IriReference "http://example.com/object2"))
             let triplepattern =  {
-                                 TriplePattern.Subject = ResourceOrVariable.Resource subjectIndex
-                                 TriplePattern.Predicate =  ResourceOrVariable.Resource predIndex
-                                 TriplePattern.Object = ResourceOrVariable.Resource objdIndex}
+                                 TriplePattern.Subject = Term.Resource subjectIndex
+                                 TriplePattern.Predicate =  Term.Resource predIndex
+                                 TriplePattern.Object = Term.Resource objdIndex}
             let triplepattern2 = PositiveTriple {
-                             TriplePattern.Subject = ResourceOrVariable.Resource subjectIndex
+                             TriplePattern.Subject = Term.Resource subjectIndex
                              TriplePattern.Predicate =  Variable "p"
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex2
+                             TriplePattern.Object = Term.Resource objdIndex2
                              }
             let rule = {Head = NormalHead triplepattern; Body = [triplepattern2]}
             
@@ -190,13 +190,13 @@ module PredicateGrounderTests =
                                  }
             tripleTable.AddTriple triple
             let triplepattern =  {
-                                 TriplePattern.Subject = ResourceOrVariable.Resource subjectIndex
+                                 TriplePattern.Subject = Term.Resource subjectIndex
                                  TriplePattern.Predicate =  Variable "p"
-                                 TriplePattern.Object = ResourceOrVariable.Resource objdIndex}
+                                 TriplePattern.Object = Term.Resource objdIndex}
             let triplepattern2 = PositiveTriple {
-                             TriplePattern.Subject = ResourceOrVariable.Resource subjectIndex
+                             TriplePattern.Subject = Term.Resource subjectIndex
                              TriplePattern.Predicate =  Variable "p"
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex2
+                             TriplePattern.Object = Term.Resource objdIndex2
                             }
             let rule = {Head = NormalHead triplepattern; Body = [triplepattern2]}
             

--- a/test/Datalog.Test/Tests.fs
+++ b/test/Datalog.Test/Tests.fs
@@ -460,7 +460,7 @@ module Tests =
             let rule =  {Head = NormalHead (headPattern)
                          Body = [ positiveMatch; negativeMatch ]
             }
-            let partitioner  = Stratifier.RulePartitioner (logger, [rule])
+            let partitioner  = Stratifier.RulePartitioner (logger, [rule], tripleTable.Resources)
             let ordered_relations = partitioner.GetOrderedRelations()
             ordered_relations.Should().HaveLength(3) |> ignore
             let init_queue = partitioner.GetReadyElementsQueue()
@@ -496,11 +496,11 @@ module Tests =
             
             
             let rule =  {Head = NormalHead (headPattern); Body = [ positiveMatch ] }
-            let partitioner  = Stratifier.RulePartitioner (logger, [rule])
-            let cycles = partitioner.cycle_finder [] 0
+            let partitioner  = Stratifier.RulePartitioner (logger, [rule], tripleTable.Resources)
+            let cycles = partitioner.cycle_finder [] 0u
             cycles.Should().HaveLength(1) |> ignore
             let cycle = cycles |> Seq.head
-            cycle.Should().HaveLength(1).And.Contain(0) |> ignore
+            cycle.Should().HaveLength(1) |> ignore
             
     (* Tests a program with a single fact *)
     [<Fact>]
@@ -549,7 +549,7 @@ module Tests =
             
             
             let rule =  {Head = NormalHead (headPattern); Body = [ positiveMatch ] }
-            let partitioner  = Stratifier.RulePartitioner (logger, [rule])
+            let partitioner  = Stratifier.RulePartitioner (logger, [rule], tripleTable.Resources)
             let orderedRules = partitioner.orderRules
             orderedRules.Should().HaveLength(1) |> ignore
             let firstPartition = orderedRules |> Seq.head
@@ -580,7 +580,7 @@ module Tests =
             let rule =  {Head = NormalHead (headPattern); Body = [ negativeMatch
                                                        ]
             }
-            let partitioner  = Stratifier.RulePartitioner (logger, [rule])
+            let partitioner  = Stratifier.RulePartitioner (logger, [rule], tripleTable.Resources)
             (fun () -> partitioner.orderRules).Should().Throw<Exception,_>() |> ignore
               
     [<Fact>]
@@ -620,7 +620,7 @@ module Tests =
             let rule =  {Head =  NormalHead headPattern
                          Body = [ positiveMatch; negativeMatch ]
             }
-            let partitioner  = Stratifier.RulePartitioner (logger, [rule])
+            let partitioner  = Stratifier.RulePartitioner (logger, [rule], tripleTable.Resources)
             let ordered_relations = partitioner.GetOrderedRelations()
             ordered_relations.Should().HaveLength(2) |> ignore
             let init_queue = partitioner.GetReadyElementsQueue()
@@ -685,7 +685,7 @@ module Tests =
             let ruleB = {Head = NormalHead (headPatternB)
                          Body = [ negativeMatch ]
             }
-            let partitioner  = Stratifier.RulePartitioner (logger, [ruleA; ruleB])
+            let partitioner  = Stratifier.RulePartitioner (logger, [ruleA; ruleB], tripleTable.Resources)
             let ordered_relations = partitioner.GetOrderedRelations()
             ordered_relations.Should().HaveLength(3) |> ignore
             

--- a/test/Datalog.Test/Tests.fs
+++ b/test/Datalog.Test/Tests.fs
@@ -42,13 +42,13 @@ module Tests =
         let objdIndex = tripleTable.AddNodeResource(Iri(new IriReference "http://example.com/object"))
         let objdIndex2 = tripleTable.AddNodeResource(Iri(new IriReference "http://example.com/object2"))
         let triplepattern =  {
-                             TriplePattern.Subject = ResourceOrVariable.Resource subjectIndex
+                             TriplePattern.Subject = Term.Resource subjectIndex
                              TriplePattern.Predicate =  Variable "p"
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex}
+                             TriplePattern.Object = Term.Resource objdIndex}
         let triplepattern2 = PositiveTriple {
-                             TriplePattern.Subject = ResourceOrVariable.Resource subjectIndex
+                             TriplePattern.Subject = Term.Resource subjectIndex
                              TriplePattern.Predicate =  Variable "p"
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex2
+                             TriplePattern.Object = Term.Resource objdIndex2
                              }
         let tripleFact : Triple = {
                              subject = subjectIndex
@@ -70,13 +70,13 @@ module Tests =
         let objdIndex2 = tripleTable.AddNodeResource(Iri(new IriReference "http://example.com/object2"))
         let objdIndex3 = tripleTable.AddNodeResource(Iri(new IriReference "http://example.com/object3"))
         let triplepattern = {
-                             TriplePattern.Subject = ResourceOrVariable.Resource subjectIndex
+                             TriplePattern.Subject = Term.Resource subjectIndex
                              TriplePattern.Predicate =  Variable "p"
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex}
+                             TriplePattern.Object = Term.Resource objdIndex}
         let triplepattern2 = PositiveTriple{
-                             TriplePattern.Subject = ResourceOrVariable.Resource subjectIndex
+                             TriplePattern.Subject = Term.Resource subjectIndex
                              TriplePattern.Predicate =  Variable "p"
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex2
+                             TriplePattern.Object = Term.Resource objdIndex2
                              }
         let tripleFact : Triple = {
                              subject = subjectIndex
@@ -105,9 +105,9 @@ module Tests =
         let subjectIndex = tripleTable.AddNodeResource(Iri(new IriReference "http://example.com/subject"))
         let predIndex = tripleTable.AddNodeResource(Iri(new IriReference "http://example.com/predicate"))
         let objdIndex = tripleTable.AddNodeResource(Iri(new IriReference "http://example.com/object"))
-        let triplepattern = {TriplePattern.Subject = ResourceOrVariable.Resource subjectIndex
+        let triplepattern = {TriplePattern.Subject = Term.Resource subjectIndex
                              TriplePattern.Predicate =  Variable "p"
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex}
+                             TriplePattern.Object = Term.Resource objdIndex}
         let wildcards = WildcardTriplePattern triplepattern
         Assert.Equal(4, wildcards.Length)
         
@@ -129,9 +129,9 @@ module Tests =
         let subjectIndex = tripleTable.AddNodeResource(Iri(new IriReference "http://example.com/subject"))
         let predIndex = tripleTable.AddNodeResource(Iri(new IriReference "http://example.com/predicate"))
         let objdIndex = tripleTable.AddNodeResource(Iri(new IriReference "http://example.com/object"))
-        let triplepattern = {TriplePattern.Subject = ResourceOrVariable.Resource subjectIndex
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndex
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex}
+        let triplepattern = {TriplePattern.Subject = Term.Resource subjectIndex
+                             TriplePattern.Predicate = Term.Resource predIndex
+                             TriplePattern.Object = Term.Resource objdIndex}
         let wildcards = WildcardTriplePattern triplepattern
         Assert.Equal(8, wildcards.Length)
         
@@ -157,9 +157,9 @@ module Tests =
         let rule =  {Head =  NormalHead ( ConstantTriplePattern Triple2 )
                      Body = [ RuleAtom.PositiveTriple (ConstantTriplePattern Triple)]}
         let TriplePatter = {
-                            TriplePattern.Subject = ResourceOrVariable.Resource subjectIndex
-                            TriplePattern.Predicate = ResourceOrVariable.Resource predIndex
-                            TriplePattern.Object = ResourceOrVariable.Resource objdIndex
+                            TriplePattern.Subject = Term.Resource subjectIndex
+                            TriplePattern.Predicate = Term.Resource predIndex
+                            TriplePattern.Object = Term.Resource objdIndex
                             }
         let partialRule = {Rule = rule; Match =  TriplePatter}
         let matches = GetMatchesForRule Triple partialRule
@@ -190,9 +190,9 @@ module Tests =
             let rule =  {Head =  NormalHead( ConstantTriplePattern Triple2 )
                          Body = [ RuleAtom.PositiveTriple (ConstantTriplePattern Triple) ; RuleAtom.NotTriple (ConstantTriplePattern Triple3)]}
             let TriplePatter = {
-                                TriplePattern.Subject = ResourceOrVariable.Resource subjectIndex
-                                TriplePattern.Predicate = ResourceOrVariable.Resource predIndex
-                                TriplePattern.Object = ResourceOrVariable.Resource objdIndex
+                                TriplePattern.Subject = Term.Resource subjectIndex
+                                TriplePattern.Predicate = Term.Resource predIndex
+                                TriplePattern.Object = Term.Resource objdIndex
                                 }
             let partialRule = {Rule = rule; Match =  TriplePatter}
             let matches = GetMatchesForRule Triple partialRule
@@ -217,14 +217,14 @@ module Tests =
             tripleTable.AddTriple(Subject2Obj2)
             
             let headPattern = {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndex
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex3
+                             TriplePattern.Subject = Term.Variable "s"
+                             TriplePattern.Predicate = Term.Resource predIndex
+                             TriplePattern.Object = Term.Resource objdIndex3
                              }
             let positiveMatch = RuleAtom.PositiveTriple {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndex
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex
+                             TriplePattern.Subject = Term.Variable "s"
+                             TriplePattern.Predicate = Term.Resource predIndex
+                             TriplePattern.Object = Term.Resource objdIndex
                              }
             let rule =  {Head = headPattern |> NormalHead
                          Body = [ positiveMatch //; negativeMatch
@@ -255,14 +255,14 @@ module Tests =
             tripleTable.AddTriple(Subject2Obj2)
             
             let headPattern = {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndex
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex3
+                             TriplePattern.Subject = Term.Variable "s"
+                             TriplePattern.Predicate = Term.Resource predIndex
+                             TriplePattern.Object = Term.Resource objdIndex3
                              }
             let positiveMatch = RuleAtom.PositiveTriple {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndex
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex
+                             TriplePattern.Subject = Term.Variable "s"
+                             TriplePattern.Predicate = Term.Resource predIndex
+                             TriplePattern.Object = Term.Resource objdIndex
                              }
             let rule =  {Head = NormalHead (headPattern); Body = [ positiveMatch //; negativeMatch
                                                                      ]}
@@ -290,14 +290,14 @@ module Tests =
             tripleTable.AddTriple(Subject2Obj2)
             
             let headPattern = {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndex
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex3
+                             TriplePattern.Subject = Term.Variable "s"
+                             TriplePattern.Predicate = Term.Resource predIndex
+                             TriplePattern.Object = Term.Resource objdIndex3
                              }
             let positiveMatch = RuleAtom.PositiveTriple {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndex
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex
+                             TriplePattern.Subject = Term.Variable "s"
+                             TriplePattern.Predicate = Term.Resource predIndex
+                             TriplePattern.Object = Term.Resource objdIndex
                              }
             
             let rule =  {Head = NormalHead (headPattern); Body = [ positiveMatch //; negativeMatch
@@ -327,19 +327,19 @@ module Tests =
             Assert.Equal(0, matchesBefore.Length)
           
             let headPattern = {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "?x"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource rdfTypeIndex
-                             TriplePattern.Object = ResourceOrVariable.Variable "?super"
+                             TriplePattern.Subject = Term.Variable "?x"
+                             TriplePattern.Predicate = Term.Resource rdfTypeIndex
+                             TriplePattern.Object = Term.Variable "?super"
                              }
             let subClassTypeAtom = RuleAtom.PositiveTriple {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "?x"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource rdfTypeIndex
-                             TriplePattern.Object = ResourceOrVariable.Variable "?sub"
+                             TriplePattern.Subject = Term.Variable "?x"
+                             TriplePattern.Predicate = Term.Resource rdfTypeIndex
+                             TriplePattern.Object = Term.Variable "?sub"
                              }
             let isSubClassOfAtom = RuleAtom.PositiveTriple {
-                                    TriplePattern.Subject = ResourceOrVariable.Variable "?sub"
-                                    TriplePattern.Predicate = ResourceOrVariable.Resource subClassOfIndex
-                                    TriplePattern.Object = ResourceOrVariable.Variable "?super" 
+                                    TriplePattern.Subject = Term.Variable "?sub"
+                                    TriplePattern.Predicate = Term.Resource subClassOfIndex
+                                    TriplePattern.Object = Term.Variable "?super" 
                                     }
             let rule =  {Head = NormalHead (headPattern); Body = [ subClassTypeAtom; isSubClassOfAtom ]}
             
@@ -370,9 +370,9 @@ module Tests =
             
             
             let triplePattern2 = {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s2"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndex2
-                             TriplePattern.Object = ResourceOrVariable.Variable "s"
+                             TriplePattern.Subject = Term.Variable "s2"
+                             TriplePattern.Predicate = Term.Resource predIndex2
+                             TriplePattern.Object = Term.Variable "s"
                              }
            
             let typedTriples = tripleTable.GetTriplesWithObject(objdIndex)
@@ -400,20 +400,20 @@ module Tests =
             tripleTable.AddTriple(Subject1Subj2)
             
             let headPattern = {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndex
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex
+                             TriplePattern.Subject = Term.Variable "s"
+                             TriplePattern.Predicate = Term.Resource predIndex
+                             TriplePattern.Object = Term.Resource objdIndex
                              }
             let positiveMatch1 = RuleAtom.PositiveTriple {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s2"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndex
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex
+                             TriplePattern.Subject = Term.Variable "s2"
+                             TriplePattern.Predicate = Term.Resource predIndex
+                             TriplePattern.Object = Term.Resource objdIndex
                              }
             
             let positiveMatch2 = RuleAtom.PositiveTriple {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s2"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndex2
-                             TriplePattern.Object = ResourceOrVariable.Variable "s"
+                             TriplePattern.Subject = Term.Variable "s2"
+                             TriplePattern.Predicate = Term.Resource predIndex2
+                             TriplePattern.Object = Term.Variable "s"
                              }
             
             let rule =  {Head = NormalHead (headPattern); Body = [ positiveMatch1 ; positiveMatch2
@@ -441,20 +441,20 @@ module Tests =
             tripleTable.AddTriple(Subject2Obj2)
             
             let headPattern = {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndex
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex3
+                             TriplePattern.Subject = Term.Variable "s"
+                             TriplePattern.Predicate = Term.Resource predIndex
+                             TriplePattern.Object = Term.Resource objdIndex3
                              }
             let positiveMatch = RuleAtom.PositiveTriple {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndex
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex
+                             TriplePattern.Subject = Term.Variable "s"
+                             TriplePattern.Predicate = Term.Resource predIndex
+                             TriplePattern.Object = Term.Resource objdIndex
                              }
             
             let negativeMatch = RuleAtom.NotTriple {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndex
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex2
+                             TriplePattern.Subject = Term.Variable "s"
+                             TriplePattern.Predicate = Term.Resource predIndex
+                             TriplePattern.Object = Term.Resource objdIndex2
                              }
             
             let rule =  {Head = NormalHead (headPattern)
@@ -484,14 +484,14 @@ module Tests =
             let objdIndex = tripleTable.AddNodeResource(Iri(new IriReference "http://example.com/object"))
             
             let headPattern = {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndex
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex
+                             TriplePattern.Subject = Term.Variable "s"
+                             TriplePattern.Predicate = Term.Resource predIndex
+                             TriplePattern.Object = Term.Resource objdIndex
                              }
             let positiveMatch = RuleAtom.PositiveTriple {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndex
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex
+                             TriplePattern.Subject = Term.Variable "s"
+                             TriplePattern.Predicate = Term.Resource predIndex
+                             TriplePattern.Object = Term.Resource objdIndex
                              }
             
             
@@ -514,9 +514,9 @@ module Tests =
             query1.Should().HaveLength(0) |> ignore
             
             let headPattern = {
-                             TriplePattern.Subject = ResourceOrVariable.Resource subjIndex
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndex
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex
+                             TriplePattern.Subject = Term.Resource subjIndex
+                             TriplePattern.Predicate = Term.Resource predIndex
+                             TriplePattern.Object = Term.Resource objdIndex
                              }
             
             
@@ -537,14 +537,14 @@ module Tests =
             
             
             let headPattern = {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndex
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex
+                             TriplePattern.Subject = Term.Variable "s"
+                             TriplePattern.Predicate = Term.Resource predIndex
+                             TriplePattern.Object = Term.Resource objdIndex
                              }
             let positiveMatch = RuleAtom.PositiveTriple {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndex
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex
+                             TriplePattern.Subject = Term.Variable "s"
+                             TriplePattern.Predicate = Term.Resource predIndex
+                             TriplePattern.Object = Term.Resource objdIndex
                              }
             
             
@@ -566,15 +566,15 @@ module Tests =
             let objdIndex = tripleTable.AddNodeResource(Iri(new IriReference "http://example.com/object"))
             
             let headPattern = {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndex
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex
+                             TriplePattern.Subject = Term.Variable "s"
+                             TriplePattern.Predicate = Term.Resource predIndex
+                             TriplePattern.Object = Term.Resource objdIndex
                              }
             
             let negativeMatch = RuleAtom.NotTriple {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndex
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex
+                             TriplePattern.Subject = Term.Variable "s"
+                             TriplePattern.Predicate = Term.Resource predIndex
+                             TriplePattern.Object = Term.Resource objdIndex
                              }
             
             let rule =  {Head = NormalHead (headPattern); Body = [ negativeMatch
@@ -601,20 +601,20 @@ module Tests =
             tripleTable.AddTriple(Subject2Obj2)
             
             let headPattern = {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndex
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex3
+                             TriplePattern.Subject = Term.Variable "s"
+                             TriplePattern.Predicate = Term.Resource predIndex
+                             TriplePattern.Object = Term.Resource objdIndex3
                              }
             let positiveMatch = RuleAtom.PositiveTriple {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndex
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex
+                             TriplePattern.Subject = Term.Variable "s"
+                             TriplePattern.Predicate = Term.Resource predIndex
+                             TriplePattern.Object = Term.Resource objdIndex
                              }
             
             let negativeMatch = RuleAtom.NotTriple {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndex
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex3
+                             TriplePattern.Subject = Term.Variable "s"
+                             TriplePattern.Predicate = Term.Resource predIndex
+                             TriplePattern.Object = Term.Resource objdIndex3
                              }
             
             let rule =  {Head =  NormalHead headPattern
@@ -652,31 +652,31 @@ module Tests =
             let objdIndex2 = tripleTable.AddNodeResource(Iri(new IriReference "http://example.com/object2"))
             
             let headPatternA = {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndexA
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex
+                             TriplePattern.Subject = Term.Variable "s"
+                             TriplePattern.Predicate = Term.Resource predIndexA
+                             TriplePattern.Object = Term.Resource objdIndex
                              }
             let headPatternB = {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndexB
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex
+                             TriplePattern.Subject = Term.Variable "s"
+                             TriplePattern.Predicate = Term.Resource predIndexB
+                             TriplePattern.Object = Term.Resource objdIndex
                              }
             let positiveMatchA = RuleAtom.PositiveTriple {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndexA
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex
+                             TriplePattern.Subject = Term.Variable "s"
+                             TriplePattern.Predicate = Term.Resource predIndexA
+                             TriplePattern.Object = Term.Resource objdIndex
                              }
             
             let positiveMatchB = RuleAtom.PositiveTriple {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndexB
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex
+                             TriplePattern.Subject = Term.Variable "s"
+                             TriplePattern.Predicate = Term.Resource predIndexB
+                             TriplePattern.Object = Term.Resource objdIndex
                              }
             
             let negativeMatch = RuleAtom.NotTriple {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndexC
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex2
+                             TriplePattern.Subject = Term.Variable "s"
+                             TriplePattern.Predicate = Term.Resource predIndexC
+                             TriplePattern.Object = Term.Resource objdIndex2
                              }
             
             let ruleA =  {Head = NormalHead (headPatternA)
@@ -714,20 +714,20 @@ module Tests =
             tripleTable.AddTriple(Subject2Obj2)
             
             let headPattern = {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndex
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex3
+                             TriplePattern.Subject = Term.Variable "s"
+                             TriplePattern.Predicate = Term.Resource predIndex
+                             TriplePattern.Object = Term.Resource objdIndex3
                              }
             let positiveMatch = RuleAtom.PositiveTriple {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndex
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex
+                             TriplePattern.Subject = Term.Variable "s"
+                             TriplePattern.Predicate = Term.Resource predIndex
+                             TriplePattern.Object = Term.Resource objdIndex
                              }
             
             let negativeMatch = RuleAtom.NotTriple {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource predIndex2
-                             TriplePattern.Object = ResourceOrVariable.Resource objdIndex2
+                             TriplePattern.Subject = Term.Variable "s"
+                             TriplePattern.Predicate = Term.Resource predIndex2
+                             TriplePattern.Object = Term.Resource objdIndex2
                              }
             
             let rule =  {Head = NormalHead (headPattern)
@@ -740,14 +740,14 @@ module Tests =
     [<Fact>]
     let ``Can get substitution``() =
         let resource = 1u
-        let variable = ResourceOrVariable.Variable "s"
+        let variable = Term.Variable "s"
         let subbed = GetSubstitution (resource, variable) (Map.empty)
         Assert.Equal(1u, subbed.Value.["s"])
     
     [<Fact>]
     let ``Can get substitution option``() =
         let resource = 1u
-        let variable = ResourceOrVariable.Variable "s"
+        let variable = Term.Variable "s"
         let subbed = GetSubstitutionOption (Some Map.empty) (resource, variable) 
         Assert.Equal(1u, subbed.Value.["s"])
         
@@ -755,9 +755,9 @@ module Tests =
     let ``Can get substitutions option``() =
         let fact = {Ingress.Triple.subject = 1u; predicate = 2u; obj = 3u}
         let factPattern = {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s"
-                             TriplePattern.Predicate = ResourceOrVariable.Variable "p"
-                             TriplePattern.Object = ResourceOrVariable.Variable "o"}
+                             TriplePattern.Subject = Term.Variable "s"
+                             TriplePattern.Predicate = Term.Variable "p"
+                             TriplePattern.Object = Term.Variable "o"}
         
         let subbed = GetSubstitutions Map.empty fact factPattern 
         Assert.Equal(1u, subbed.Value.["s"])
@@ -769,9 +769,9 @@ module Tests =
     let ``Can get substitutions option map``() =
         let fact = {Ingress.Triple.subject = 1u; predicate = 2u; obj = 3u}
         let factPattern = {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource 2u
-                             TriplePattern.Object = ResourceOrVariable.Variable "o"}
+                             TriplePattern.Subject = Term.Variable "s"
+                             TriplePattern.Predicate = Term.Resource 2u
+                             TriplePattern.Object = Term.Variable "o"}
         
         let subbed = GetSubstitutions Map.empty fact factPattern 
         Assert.Equal(1u, subbed.Value.["s"])
@@ -783,9 +783,9 @@ module Tests =
     let ``Can increase substitutions option map``() =
         let fact = {Ingress.Triple.subject = 1u; predicate = 2u; obj = 3u}
         let factPattern = {
-                             TriplePattern.Subject = ResourceOrVariable.Variable "s"
-                             TriplePattern.Predicate = ResourceOrVariable.Resource 2u
-                             TriplePattern.Object = ResourceOrVariable.Variable "o"}
+                             TriplePattern.Subject = Term.Variable "s"
+                             TriplePattern.Predicate = Term.Resource 2u
+                             TriplePattern.Object = Term.Variable "o"}
         
         let subbed = GetSubstitutions (Map.empty.Add ("t", 2u)) fact factPattern 
         Assert.Equal(1u, subbed.Value.["s"])
@@ -794,7 +794,7 @@ module Tests =
     [<Fact>]
     let ``No subsititution if mismatch``() =
         let resource = 1u
-        let variable = ResourceOrVariable.Variable "s"
+        let variable = Term.Variable "s"
         let subbed = GetSubstitution (resource, variable) (Map.empty.Add("s", 2u))
         Assert.Equal(None, subbed)
     

--- a/test/DatalogParser.Unit.Tests/TestParser.cs
+++ b/test/DatalogParser.Unit.Tests/TestParser.cs
@@ -114,20 +114,20 @@ public class TestParser
         ruleAtom.Should().NotBeNull();
         ruleAtom.IsPositiveTriple.Should().BeTrue();
         var ruleTriplePattern = ((RuleAtom.PositiveTriple)ruleAtom).Item;
-        ruleTriplePattern.Subject.Should().Be(ResourceOrVariable.NewVariable("?s"));
+        ruleTriplePattern.Subject.Should().Be(Term.NewVariable("?s"));
 
-        var predicateResource = ResourceOrVariable
+        var predicateResource = Term
             .NewResource(datastore.AddNodeResource(RdfResource
                 .NewIri(new IriReference("https://example.com/data#predicate2"))));
         ruleTriplePattern.Predicate.Should().Be(predicateResource);
 
-        var objectResource = ResourceOrVariable
+        var objectResource = Term
             .NewResource(datastore.AddNodeResource(RdfResource
                 .NewIri(new IriReference("https://example.com/data3#obj"))));
         ruleTriplePattern.Object.Should().Be(objectResource);
 
         ruleAtom.Should().Be(RuleAtom.NewPositiveTriple(new TriplePattern(
-            ResourceOrVariable.NewVariable("?s"),
+            Term.NewVariable("?s"),
             predicateResource,
             objectResource)));
     }
@@ -144,16 +144,16 @@ public class TestParser
         var parsedDatalogRule = ont.First();
         parsedDatalogRule.Body.Count().Should().Be(2);
         parsedDatalogRule.Body.First().Should().Be(RuleAtom.NewPositiveTriple(new TriplePattern(
-            ResourceOrVariable.NewVariable("?x"),
-            ResourceOrVariable.NewVariable("?p"),
-            ResourceOrVariable.NewVariable("?y"))));
-        var rdfTypeResource = ResourceOrVariable
+            Term.NewVariable("?x"),
+            Term.NewVariable("?p"),
+            Term.NewVariable("?y"))));
+        var rdfTypeResource = Term
             .NewResource(datastore.AddNodeResource(RdfResource
                 .NewIri(new IriReference(Namespaces.RdfType))));
         var expectedHead = RuleHead.NewNormalHead(new TriplePattern(
-            ResourceOrVariable.NewVariable("?x"),
+            Term.NewVariable("?x"),
             rdfTypeResource,
-            ResourceOrVariable.NewVariable("?c")));
+            Term.NewVariable("?c")));
         expectedHead.Should().NotBeNull();
         parsedDatalogRule.Head.Should().NotBeNull();
         parsedDatalogRule.Head.Should().Be(expectedHead);
@@ -171,19 +171,19 @@ public class TestParser
         ont.Should().HaveCount(1);
         ont.First().Body.Count().Should().Be(1);
         ont.First().Head.Should().Be(RuleHead.NewNormalHead(new TriplePattern(
-            ResourceOrVariable.NewVariable("?new_node"),
-            ResourceOrVariable
+            Term.NewVariable("?new_node"),
+            Term
                 .NewResource(datastore.GetGraphNodeId(RdfResource.NewIri(new IriReference("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")))),
-            ResourceOrVariable
+            Term
                 .NewResource(datastore.GetGraphNodeId(RdfResource
                     .NewIri(new IriReference("https://example.com/data#type")))))));
 
         ont.First().Body.First().Should().Be(RuleAtom.NewPositiveTriple(new TriplePattern(
-            ResourceOrVariable.NewVariable("?node"),
-            ResourceOrVariable
+            Term.NewVariable("?node"),
+            Term
                 .NewResource(datastore.GetGraphNodeId(RdfResource
                     .NewIri(new IriReference("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")))),
-            ResourceOrVariable
+            Term
                 .NewResource(datastore.GetGraphNodeId(RdfResource
                     .NewIri(new IriReference("https://example.com/data#type")))))));
     }

--- a/test/ELI.Tests/Tests.fs
+++ b/test/ELI.Tests/Tests.fs
@@ -93,19 +93,19 @@ module TestClassAxioms =
         //Assert
         let expectedRules: Datalog.Rule seq =
             [ { Head = NormalHead
-                  { Subject = ResourceOrVariable.Variable "X"
-                    Predicate = ResourceOrVariable.Resource(resources.AddNodeResource(Iri(IriReference Namespaces.RdfType)))
+                  { Subject = Term.Variable "X"
+                    Predicate = Term.Resource(resources.AddNodeResource(Iri(IriReference Namespaces.RdfType)))
                     Object =
-                      ResourceOrVariable.Resource(
+                      Term.Resource(
                           resources.AddNodeResource(Iri(IriReference "https://example.com/superclass"))
                       ) }
                 Body =
                   [ PositiveTriple
-                        { Subject = ResourceOrVariable.Variable "X"
+                        { Subject = Term.Variable "X"
                           Predicate =
-                            ResourceOrVariable.Resource(resources.AddNodeResource(Iri(IriReference Namespaces.RdfType)))
+                            Term.Resource(resources.AddNodeResource(Iri(IriReference Namespaces.RdfType)))
                           Object =
-                            ResourceOrVariable.Resource(
+                            Term.Resource(
                                 resources.AddNodeResource(Iri(IriReference "https://example.com/subclass"))
                             ) } ] } ]
 

--- a/test/Ingress.Tests/Ingress.Tests.fsproj
+++ b/test/Ingress.Tests/Ingress.Tests.fsproj
@@ -14,6 +14,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0"/>
+        <PackageReference Include="Serilog.Sinks.InMemory" Version="0.11.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/OWL2RL2Datalog.Tests/TestClassAxioms.fs
+++ b/test/OWL2RL2Datalog.Tests/TestClassAxioms.fs
@@ -122,9 +122,9 @@ module TestClassAxioms =
         
         let rdfTypeResource = tripleTable.Resources.AddResource (NodeOrEdge (Iri (IriReference Namespaces.RdfType)))
         let ruleHead =
-            NormalHead {Subject = ResourceOrVariable.Variable "X"
-                        Predicate = ResourceOrVariable.Resource rdfTypeResource
-                        Object = ResourceOrVariable.Resource Aresource}
+            NormalHead {Subject = Term.Variable "X"
+                        Predicate = Term.Resource rdfTypeResource
+                        Object = Term.Resource Aresource}
         
         let Arules = rlProgram |> Seq.filter (fun rule -> rule.Head = ruleHead)
         Arules.Should().NotBeEmpty() |> ignore
@@ -161,26 +161,26 @@ module TestClassAxioms =
         
         let rdfTypeResource = tripleTable.Resources.AddResource (NodeOrEdge (Iri (IriReference Namespaces.RdfType)))
         let ruleHead =
-            NormalHead {Subject = ResourceOrVariable.Variable "X"
-                        Predicate = ResourceOrVariable.Resource rdfTypeResource
-                        Object = ResourceOrVariable.Resource Aresource}
+            NormalHead {Subject = Term.Variable "X"
+                        Predicate = Term.Resource rdfTypeResource
+                        Object = Term.Resource Aresource}
         let expectedAxiom = {
             DagSemTools.Datalog.Head = ruleHead
             DagSemTools.Datalog.Body = [
                 PositiveTriple {
-                    Subject = ResourceOrVariable.Variable "X"
-                    Predicate = ResourceOrVariable.Resource roleresource
-                    Object = ResourceOrVariable.Variable "X_1"
+                    Subject = Term.Variable "X"
+                    Predicate = Term.Resource roleresource
+                    Object = Term.Variable "X_1"
                 };
                 PositiveTriple{
-                 Subject = ResourceOrVariable.Variable "X_1"
-                 Predicate = ResourceOrVariable.Resource rdfTypeResource
-                 Object = ResourceOrVariable.Resource Fresource
+                 Subject = Term.Variable "X_1"
+                 Predicate = Term.Resource rdfTypeResource
+                 Object = Term.Resource Fresource
                  };
                 PositiveTriple{
-                 Subject = ResourceOrVariable.Variable "X_1"
-                 Predicate = ResourceOrVariable.Resource rdfTypeResource
-                 Object = ResourceOrVariable.Resource Eresource
+                 Subject = Term.Variable "X_1"
+                 Predicate = Term.Resource rdfTypeResource
+                 Object = Term.Resource Eresource
                  }]
         }
         let Arules = rlProgram |> Seq.filter (fun rule -> rule.Head = ruleHead)

--- a/test/OWL2RL2Datalog.Tests/TestClassAxioms.fs
+++ b/test/OWL2RL2Datalog.Tests/TestClassAxioms.fs
@@ -49,7 +49,7 @@ module TestClassAxioms =
         let query = tripleTable.GetTriplesWithSubjectObject(subjectIndex, objIndex2)
         query.Should().HaveLength(0) |> ignore
         
-        let ontologyTranslator = new RdfOwlTranslator.Rdf2Owl(tripleTable.Triples, tripleTable.Resources)
+        let ontologyTranslator = new RdfOwlTranslator.Rdf2Owl(tripleTable.Triples, tripleTable.Resources, logger)
         let ontology = ontologyTranslator.extractOntology
         let rlProgram = Library.owl2Datalog logger tripleTable.Resources ontology
         DagSemTools.Datalog.Reasoner.evaluate (logger, rlProgram |> Seq.toList, tripleTable)
@@ -83,7 +83,7 @@ module TestClassAxioms =
         let query = tripleTable.GetTriplesWithSubjectObject(subjectIndex, objIndex2)
         query.Should().HaveLength(0) |> ignore
         
-        let ontologyTranslator = new RdfOwlTranslator.Rdf2Owl(tripleTable.Triples, tripleTable.Resources)
+        let ontologyTranslator = new RdfOwlTranslator.Rdf2Owl(tripleTable.Triples, tripleTable.Resources, logger)
         let ontology = ontologyTranslator.extractOntology
         let rlProgram = Library.owl2Datalog logger tripleTable.Resources ontology
         DagSemTools.Datalog.Reasoner.evaluate (logger, rlProgram |> Seq.toList, tripleTable)
@@ -212,7 +212,7 @@ module TestClassAxioms =
         let query = tripleTable.GetTriplesWithSubjectObject(subjectIndex, objIndex2)
         query.Should().HaveLength(1) |> ignore
         
-        let ontologyTranslator = new RdfOwlTranslator.Rdf2Owl(tripleTable.Triples, tripleTable.Resources)
+        let ontologyTranslator = new RdfOwlTranslator.Rdf2Owl(tripleTable.Triples, tripleTable.Resources, logger)
         let ontology = ontologyTranslator.extractOntology
         let rlProgram = Library.owl2Datalog logger tripleTable.Resources ontology
         DagSemTools.Datalog.Reasoner.evaluate (logger, rlProgram |> Seq.toList, tripleTable)

--- a/test/OWL2RL2Datalog.Tests/TestEqualityAxioms.fs
+++ b/test/OWL2RL2Datalog.Tests/TestEqualityAxioms.fs
@@ -72,7 +72,7 @@ module DagSemTools.OWL2RL2Datalog.TestEqualityAxioms
             }
         let rule : Rule = {Head = NormalHead ( triplePattern "s1" )
                            Body = [PositiveTriple (triplePattern "s2")]}
-        let partitioner = DagSemTools.Datalog.Stratifier.RulePartitioner (logger, [rule])
+        let partitioner = DagSemTools.Datalog.Stratifier.RulePartitioner (logger, [rule], tripleTable.Resources)
         let stratification = partitioner.orderRules
         stratification.Should().HaveLength(1) |> ignore
 
@@ -222,7 +222,7 @@ module DagSemTools.OWL2RL2Datalog.TestEqualityAxioms
         }
         // Act
         let rules_with_iri_predicates = PredicateGrounder.groundRulePredicates([sameAsRule2], tripleTable) |> Seq.toList
-        let stratifier = Stratifier.RulePartitioner (logger, rules_with_iri_predicates)
+        let stratifier = Stratifier.RulePartitioner (logger, rules_with_iri_predicates, tripleTable.Resources)
         let relationInfos = stratifier.GetOrderedRelations()
         
         //Assert

--- a/test/OWL2RL2Datalog.Tests/TestEqualityAxioms.fs
+++ b/test/OWL2RL2Datalog.Tests/TestEqualityAxioms.fs
@@ -66,9 +66,9 @@ module DagSemTools.OWL2RL2Datalog.TestEqualityAxioms
         tripleTable.AddTriple(Triple)
         let triplePattern varName : TriplePattern =
             {
-                Subject = ResourceOrVariable.Resource subjectIndex
-                Predicate = ResourceOrVariable.Variable varName
-                Object = ResourceOrVariable.Resource objextIndex
+                Subject = Term.Resource subjectIndex
+                Predicate = Term.Variable varName
+                Object = Term.Resource objextIndex
             }
         let rule : Rule = {Head = NormalHead ( triplePattern "s1" )
                            Body = [PositiveTriple (triplePattern "s2")]}
@@ -88,9 +88,9 @@ module DagSemTools.OWL2RL2Datalog.TestEqualityAxioms
         tripleTable.AddTriple(Triple)
         let triplePattern varName : TriplePattern =
             {
-                Subject = ResourceOrVariable.Resource subjectIndex
-                Predicate = ResourceOrVariable.Variable varName
-                Object = ResourceOrVariable.Resource objextIndex
+                Subject = Term.Resource subjectIndex
+                Predicate = Term.Variable varName
+                Object = Term.Resource objextIndex
             }
         let rule : Rule = {Head = NormalHead ( triplePattern "s1" )
                            Body = [PositiveTriple (triplePattern "s2")]}
@@ -111,15 +111,15 @@ module DagSemTools.OWL2RL2Datalog.TestEqualityAxioms
         tripleTable.AddTriple(Triple)
         let headPattern : TriplePattern  =
             {
-                Subject = ResourceOrVariable.Resource subjectIndex
-                Predicate = ResourceOrVariable.Variable "p"
-                Object = ResourceOrVariable.Resource objextIndex2
+                Subject = Term.Resource subjectIndex
+                Predicate = Term.Variable "p"
+                Object = Term.Resource objextIndex2
             }
         let bodyPattern : TriplePattern  =
             {
-                Subject = ResourceOrVariable.Resource subjectIndex
-                Predicate = ResourceOrVariable.Variable "p"
-                Object = ResourceOrVariable.Resource objextIndex
+                Subject = Term.Resource subjectIndex
+                Predicate = Term.Variable "p"
+                Object = Term.Resource objextIndex
             }
         let rule : Rule = {Head = NormalHead headPattern; Body = [PositiveTriple (bodyPattern)]}
         
@@ -162,7 +162,7 @@ module DagSemTools.OWL2RL2Datalog.TestEqualityAxioms
             Body = [
                 PositiveTriple {
                     Subject = Variable "p"
-                    Predicate = ResourceOrVariable.Resource sameAsIndex
+                    Predicate = Term.Resource sameAsIndex
                     Object = Variable "p2"
                 }
                 PositiveTriple {
@@ -210,7 +210,7 @@ module DagSemTools.OWL2RL2Datalog.TestEqualityAxioms
             Body = [
                 PositiveTriple {
                     Subject = Variable "p"
-                    Predicate = ResourceOrVariable.Resource sameAsIndex
+                    Predicate = Term.Resource sameAsIndex
                     Object = Variable "p2"
                 }
                 PositiveTriple {
@@ -260,7 +260,7 @@ module DagSemTools.OWL2RL2Datalog.TestEqualityAxioms
             Body = [
                 PositiveTriple {
                     Subject = Variable "p"
-                    Predicate = ResourceOrVariable.Resource sameAsIndex
+                    Predicate = Term.Resource sameAsIndex
                     Object = Variable "p2"
                 }
                 PositiveTriple {
@@ -278,14 +278,14 @@ module DagSemTools.OWL2RL2Datalog.TestEqualityAxioms
         let correctGroundRule =  {
             Head = NormalHead {
                 Subject = Variable "s"
-                Predicate = ResourceOrVariable.Resource predIndex2
+                Predicate = Term.Resource predIndex2
                 Object = Variable "o" 
             }
             Body = [
                 PositiveTriple {
                     Subject = Variable "p"
-                    Predicate = ResourceOrVariable.Resource sameAsIndex
-                    Object = ResourceOrVariable.Resource predIndex2
+                    Predicate = Term.Resource sameAsIndex
+                    Object = Term.Resource predIndex2
                 }
                 PositiveTriple {
                     Subject = Variable "s"

--- a/test/OWL2RL2Datalog.Tests/TestEqualityAxioms.fs
+++ b/test/OWL2RL2Datalog.Tests/TestEqualityAxioms.fs
@@ -42,7 +42,7 @@ module DagSemTools.OWL2RL2Datalog.TestEqualityAxioms
         query.Should().HaveLength(1) |> ignore
         
         //Act
-        let ontologyTranslator = new RdfOwlTranslator.Rdf2Owl(tripleTable.Triples, tripleTable.Resources)
+        let ontologyTranslator = new RdfOwlTranslator.Rdf2Owl(tripleTable.Triples, tripleTable.Resources, logger)
         let ontology = ontologyTranslator.extractOntology
         let rlProgram = Library.owl2Datalog logger tripleTable.Resources ontology
         DagSemTools.Datalog.Reasoner.evaluate (logger, rlProgram |> Seq.toList, tripleTable)
@@ -315,7 +315,7 @@ module DagSemTools.OWL2RL2Datalog.TestEqualityAxioms
         let query1a = tripleTable.GetTriplesWithSubjectObject(subjectIndex, objIndex)
         query1a.Should().HaveLength(0) |> ignore
         
-        let ontologyTranslator = new RdfOwlTranslator.Rdf2Owl(tripleTable.Triples, tripleTable.Resources)
+        let ontologyTranslator = new RdfOwlTranslator.Rdf2Owl(tripleTable.Triples, tripleTable.Resources, logger)
         let ontology = ontologyTranslator.extractOntology
         let rlProgram = Library.owl2Datalog logger tripleTable.Resources ontology
         

--- a/test/OWL2RL2Datalog.Tests/TestpropertyAxioms.fs
+++ b/test/OWL2RL2Datalog.Tests/TestpropertyAxioms.fs
@@ -54,7 +54,7 @@ let ``Object Property Domain and Range RL reasoning works`` () =
     let query = tripleTable.GetTriplesWithSubjectObject(objectIndex, rangeIndex)
     query.Should().HaveLength(0) |> ignore
     
-    let ontologyTranslator = new RdfOwlTranslator.Rdf2Owl(tripleTable.Triples, tripleTable.Resources)
+    let ontologyTranslator = new RdfOwlTranslator.Rdf2Owl(tripleTable.Triples, tripleTable.Resources, logger)
     let ontology = ontologyTranslator.extractOntology
     let rlProgram = Library.owl2Datalog logger tripleTable.Resources ontology 
     DagSemTools.Datalog.Reasoner.evaluate (logger, rlProgram |> Seq.toList, tripleTable)

--- a/test/RdfOwlTranslator.Tests/RdfOwlTranslator.Tests.fsproj
+++ b/test/RdfOwlTranslator.Tests/RdfOwlTranslator.Tests.fsproj
@@ -16,6 +16,7 @@
         <PackageReference Include="Faqt" Version="4.4.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
         <PackageReference Include="Serilog" Version="4.2.0" />
+        <PackageReference Include="Serilog.Sinks.InMemory" Version="0.11.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/RdfOwlTranslator.Tests/Tests.fs
+++ b/test/RdfOwlTranslator.Tests/Tests.fs
@@ -15,9 +15,16 @@ open DagSemTools.Ingress
 open IriTools
 open DagSemTools.Rdf.Ingress
 open Faqt
+open Serilog
+open Serilog.Sinks.InMemory
 
 module Tests =
-
+    let inMemorySink = new InMemorySink()
+    let logger =
+        LoggerConfiguration()
+                .WriteTo.Sink(inMemorySink)
+                .CreateLogger()
+    
 
     [<Theory>]
     [<InlineData(Namespaces.OwlClass)>]
@@ -59,7 +66,7 @@ module Tests =
             AxiomDeclaration([], typeDeclaration (Iri.FullIri(new IriReference "http://example.com/subject")))
 
         //Act
-        let translator = new DagSemTools.RdfOwlTranslator.Rdf2Owl(tripleTable, resources)
+        let translator = new DagSemTools.RdfOwlTranslator.Rdf2Owl(tripleTable, resources, logger)
         let ontology: Ontology = translator.extractOntology
         //Assert
         let ontologyAxioms = ontology.Axioms
@@ -146,7 +153,7 @@ module Tests =
         tripleTable.AddTriple(subclassOfTriple)
 
         //Act
-        let translator = new DagSemTools.RdfOwlTranslator.Rdf2Owl(tripleTable, resources)
+        let translator = new DagSemTools.RdfOwlTranslator.Rdf2Owl(tripleTable, resources, logger)
         let ontology: Ontology = translator.extractOntology
 
         //Assert
@@ -201,7 +208,7 @@ module Tests =
         tripleTable.AddTriple(subclassOfTriple)
 
         //Act
-        let translator = new DagSemTools.RdfOwlTranslator.Rdf2Owl(tripleTable, resources)
+        let translator = new DagSemTools.RdfOwlTranslator.Rdf2Owl(tripleTable, resources, logger)
         let ontology: Ontology = translator.extractOntology
 
         //Assert
@@ -262,7 +269,7 @@ module Tests =
         tripleTable.AddTriple subClassTriple
 
         //Act
-        let translator = new DagSemTools.RdfOwlTranslator.Rdf2Owl(tripleTable, resources)
+        let translator = new DagSemTools.RdfOwlTranslator.Rdf2Owl(tripleTable, resources, logger)
         let ontology: Ontology = translator.extractOntology
 
         //Assert
@@ -366,8 +373,8 @@ module Tests =
         tripleTable.AddTriple owlIntersectionLastTriple
         
         //Act
-        let translator = new DagSemTools.RdfOwlTranslator.Rdf2Owl(tripleTable, resources)
-        let classExpressionParser = new DagSemTools.RdfOwlTranslator.ClassExpressionParser(tripleTable, resources)
+        let translator = new DagSemTools.RdfOwlTranslator.Rdf2Owl(tripleTable, resources, logger)
+        let classExpressionParser = new DagSemTools.RdfOwlTranslator.ClassExpressionParser(tripleTable, resources, logger)
         let anonExpr = classExpressionParser.parseAnonymousClassExpressions()
         anonExpr.Should().HaveLength(1) |> ignore
         let restrExpr = classExpressionParser.parseAnonymousRestrictions()
@@ -458,7 +465,7 @@ module Tests =
         
         
         //Act
-        let translator = new DagSemTools.RdfOwlTranslator.Rdf2Owl(tripleTable, resources)
+        let translator = new DagSemTools.RdfOwlTranslator.Rdf2Owl(tripleTable, resources, logger)
         let ontology: Ontology = translator.extractOntology
 
         //Assert


### PR DESCRIPTION
A bug in the translator from rdf 2 owl and in the datalog stratification algorithm were fixed. Specifically, the nromalization of axioms that included AtMost and AtMin had mixed up what expression to put on the right hand side. Also added references to the original paper about this normalization.

Changed the treatment of non-RL-profile axioms from Exception to Warning. 