### PR TITLE
Extend OWL 2 Datalog to handle IDO ontology

### DIFF
--- a/grammars/common/IriGrammar.g4
+++ b/grammars/common/IriGrammar.g4
@@ -10,14 +10,14 @@ grammar IriGrammar; // Kind of IRIs (https://www.rfc-editor.org/rfc/rfc3987#sect
 import CommonTokens, CommonTokens;
 
 rdfiri: LT IRI GT   #fullIri
-      | prefixName=LOCALNAME COLON localName=LOCALNAME  #prefixedIri
+      | prefixName=LOCALNAME COLON localName=LOCALNAME  #PrefixedIri
       | COLON? simpleName = (
             LOCALNAME 
           | DECIMALLITERAL 
           | EXPONENT 
           | INTEGERLITERAL 
           | FLOATINGPOINTLITERAL  
-      ) #emptyPrefixedIri // Numbers are valid localnames in Manchester syntax
+      ) #EmptyPrefixedIri // Numbers are valid localnames in Manchester syntax
       ;
 
 localname: LOCALNAME;

--- a/src/Ingress/Namespaces.fs
+++ b/src/Ingress/Namespaces.fs
@@ -45,7 +45,7 @@ module Namespaces =
     [<Literal>]
     let RdfReifies = Rdf + "reifies"
     [<Literal>]
-    let RdfLiteral = Rdf + "Literal";
+    let RdfsLiteral = Rdfs + "Literal";
     
     [<Literal>]
     let RdfsSubClassOf = Rdfs + "subClassOf";

--- a/src/Ingress/Namespaces.fs
+++ b/src/Ingress/Namespaces.fs
@@ -44,6 +44,8 @@ module Namespaces =
 
     [<Literal>]
     let RdfReifies = Rdf + "reifies"
+    [<Literal>]
+    let RdfLiteral = Rdf + "Literal";
     
     [<Literal>]
     let RdfsSubClassOf = Rdfs + "subClassOf";

--- a/src/OWL2RL2Datalog/Library.fs
+++ b/src/OWL2RL2Datalog/Library.fs
@@ -25,76 +25,116 @@ module Library =
             (Namespaces.RdfType, resources.AddNodeResource(RdfResource.Iri(IriReference Namespaces.RdfType))))
         |> Map.ofList
 
-    let getObjectPropertyExpressionResource (resources: GraphElementManager) objProp =
+    let rec getObjectPropertyExpressionResource
+        (logger : Serilog.ILogger)
+        (resources: GraphElementManager)
+        objProp =
         match objProp with
-        | NamedObjectProperty(FullIri iri) -> resources.AddNodeResource(RdfResource.Iri iri)
-        | AnonymousObjectProperty bNode -> resources.AddNodeResource(AnonymousBlankNode bNode)
-        | InverseObjectProperty _ ->
-            failwith "Invalid Owl Ontology: Domain of unnamed inverse object property not supported"
-        | ObjectPropertyChain _ -> failwith "Invalid Owl Ontology: Domain of object property chain not supported"
+        | NamedObjectProperty(FullIri iri) ->
+                    { TriplePattern.Subject = Term.Variable "x"
+                      Predicate = (Term.Resource (resources.AddNodeResource(RdfResource.Iri iri)))
+                      Object = Term.Variable "y" } |> Some
+        | AnonymousObjectProperty bNode ->
+                    { TriplePattern.Subject = Term.Variable "x"
+                      Predicate = Term.Resource (resources.AddNodeResource(AnonymousBlankNode bNode))
+                      Object = Term.Variable "y" } |> Some
+        | InverseObjectProperty innerObjProp ->
+                    getObjectPropertyExpressionResource logger resources objProp
+                    |> Option.map (fun innerPattern ->
+                    { TriplePattern.Subject = innerPattern.Object
+                      Predicate = innerPattern.Predicate
+                      Object = innerPattern.Subject } )
+        | ObjectPropertyChain _ -> logger.Warning "Invalid Owl Ontology: Domain of object property chain not supported"
+                                   None
 
-    let getClassExpressionResource (resources: GraphElementManager) classExpr =
+    let rec getClassExpressionResource (logger : Serilog.ILogger) (resources: GraphElementManager) classExpr =
         match classExpr with
-        | ClassName(FullIri iri) -> resources.AddNodeResource(RdfResource.Iri iri)
-        | AnonymousClass bNode -> resources.AddNodeResource(AnonymousBlankNode bNode)
-        | _ -> failwith "Unnamed class not yet implemented for this operation. Sorry"
+        | ClassName(FullIri iri) -> [resources.AddNodeResource(RdfResource.Iri iri)]
+        | AnonymousClass bNode -> [resources.AddNodeResource(AnonymousBlankNode bNode)]
+        | ObjectIntersectionOf classes -> classes |> List.collect (getClassExpressionResource logger resources)
+        | ObjectUnionOf _ -> logger.Warning $"OWL 2 RL profile does not support union in domain or range expression {classExpr}"
+                             [] 
+        | ObjectComplementOf classExpression -> failwith "todo"
+        | ObjectOneOf individuals -> failwith "todo"
+        | ObjectSomeValuesFrom(objectPropertyExpression, classExpression) -> failwith "todo"
+        | ObjectAllValuesFrom(objectPropertyExpression, classExpression) -> failwith "todo"
+        | ObjectHasValue(objectPropertyExpression, individual) -> failwith "todo"
+        | ObjectHasSelf objectPropertyExpression -> failwith "todo"
+        | ObjectMinQualifiedCardinality(i, objectPropertyExpression, classExpression) -> failwith "todo"
+        | ObjectMaxQualifiedCardinality(i, objectPropertyExpression, classExpression) -> failwith "todo"
+        | ObjectExactQualifiedCardinality(i, objectPropertyExpression, classExpression) -> failwith "todo"
+        | ObjectExactCardinality(i, objectPropertyExpression) -> failwith "todo"
+        | ObjectMinCardinality(i, objectPropertyExpression) -> failwith "todo"
+        | ObjectMaxCardinality(i, objectPropertyExpression) -> failwith "todo"
+        | DataSomeValuesFrom(iris, dataRange) -> failwith "todo"
+        | DataAllValuesFrom(iris, dataRange) -> failwith "todo"
+        | DataHasValue(iri, graphElement) -> failwith "todo"
+        | DataMinQualifiedCardinality(i, iri, dataRange) -> failwith "todo"
+        | DataMaxQualifiedCardinality(i, iri, dataRange) -> failwith "todo"
+        | DataExactQualifiedCardinality(i, iri, dataRange) -> failwith "todo"
+        | DataMinCardinality(i, iri) -> failwith "todo"
+        | DataMaxCardinality(i, iri) -> failwith "todo"
+        | DataExactCardinality(i, iri) -> failwith "todo"
+        
 
     let ObjectPropertyDomain2Datalog
+        (logger : Serilog.ILogger)
         (resourceMap: Map<string, Ingress.GraphElementId>)
         (resources: GraphElementManager)
         objProp
         domExp
         =
-        let propertyResource = getObjectPropertyExpressionResource resources objProp
-        let domainClassResource = getClassExpressionResource resources domExp
-
-        [ { Rule.Head = NormalHead
-              { TriplePattern.Subject = Term.Variable "x"
-                TriplePattern.Predicate = Term.Resource resourceMap.[Namespaces.RdfType]
-                TriplePattern.Object = Term.Resource domainClassResource }
-            Rule.Body =
-              [ (RuleAtom.PositiveTriple
-                    { Subject = Term.Variable "x"
-                      Predicate = Term.Resource propertyResource
-                      Object = Term.Variable "y" }) ] } ]
-
-
+        match getObjectPropertyExpressionResource logger resources objProp with 
+        | None -> Seq.empty
+        | Some bodyTriple ->
+            getClassExpressionResource logger resources domExp
+            |> Seq.map (fun domainClassResource ->
+                { Rule.Head = NormalHead
+                      { TriplePattern.Subject = Term.Variable "x"
+                        TriplePattern.Predicate = Term.Resource resourceMap.[Namespaces.RdfType]
+                        TriplePattern.Object = Term.Resource domainClassResource }
+                  Rule.Body =
+                      [ (RuleAtom.PositiveTriple bodyTriple ) ]
+                }
+            )
 
     let ObjectPropertyRange2Datalog
+        (logger : Serilog.ILogger)
         (resourceMap: Map<string, Ingress.GraphElementId>)
         (resources: GraphElementManager)
         objProp
         rangeExp
         =
-        let propertyResource = getObjectPropertyExpressionResource resources objProp
-        let rangeClassResource = getClassExpressionResource resources rangeExp
-
-        [ { Rule.Head = NormalHead
+        match getObjectPropertyExpressionResource logger resources objProp with 
+        | None -> Seq.empty
+        | Some bodyTriple ->
+        getClassExpressionResource logger resources rangeExp
+        |> Seq.map (fun rangeClassResource ->
+          { Rule.Head = NormalHead
               { TriplePattern.Subject = Term.Variable "y"
                 TriplePattern.Predicate = Term.Resource resourceMap.[Namespaces.RdfType]
                 TriplePattern.Object = Term.Resource rangeClassResource }
             Rule.Body =
               [ (RuleAtom.PositiveTriple
-                    { Subject = Term.Variable "x"
-                      Predicate = Term.Resource propertyResource
-                      Object = Term.Variable "y" }) ] } ]
+                    bodyTriple) ] } )
     (* prp-symp 	T(?p, rdf:type, owl:SymmetricProperty) T(?x, ?p, ?y) ->	T(?y, ?p, ?x)  *)
     let SymmetricObjectProperty2Datalog
+        (logger : Serilog.ILogger)
         (resourceMap: Map<string, Ingress.GraphElementId>)
         (resources: GraphElementManager)
         objProp
         =
-        let propertyResource = getObjectPropertyExpressionResource resources objProp
-
+        match getObjectPropertyExpressionResource logger resources objProp with 
+        | None -> Seq.empty
+        | Some bodyTriple ->
+        
         [ { Rule.Head = NormalHead
-              { TriplePattern.Subject = Term.Variable "y"
-                TriplePattern.Predicate = Term.Resource propertyResource
-                TriplePattern.Object = Term.Variable "x" }
+              { TriplePattern.Subject = bodyTriple.Object
+                TriplePattern.Predicate = bodyTriple.Predicate
+                TriplePattern.Object = bodyTriple.Subject }
             Rule.Body =
               [ (RuleAtom.PositiveTriple
-                    { Subject = Term.Variable "x"
-                      Predicate = Term.Resource propertyResource
-                      Object = Term.Variable "y" }) ] } ]
+                    bodyTriple) ] } ]
 
 
 
@@ -104,14 +144,15 @@ module Library =
         cax-eqc2 	T(?c1, owl:equivalentClass, ?c2) T(?x, rdf:type, ?c2) 	T(?x, rdf:type, ?c1) 
     *)
     let ObjectPropertyAxiom2Datalog
+        (logger : Serilog.ILogger)
         (resourceMap: Map<string, Ingress.GraphElementId>)
         (resources: GraphElementManager)
         (axiom: ObjectPropertyAxiom)
         =
         match axiom with
-        | ObjectPropertyDomain(objProp, domExp) -> ObjectPropertyDomain2Datalog resourceMap resources objProp domExp
-        | ObjectPropertyRange(objProp, rangeExp) -> ObjectPropertyRange2Datalog resourceMap resources objProp rangeExp
-        | SymmetricObjectProperty(_, objProp) -> SymmetricObjectProperty2Datalog resourceMap resources objProp
+        | ObjectPropertyDomain(objProp, domExp) -> ObjectPropertyDomain2Datalog logger resourceMap resources objProp domExp
+        | ObjectPropertyRange(objProp, rangeExp) -> ObjectPropertyRange2Datalog logger resourceMap resources objProp rangeExp
+        | SymmetricObjectProperty(_, objProp) -> SymmetricObjectProperty2Datalog logger resourceMap resources objProp
         | _ -> []
 
     let owlAxiom2Datalog logger
@@ -120,7 +161,7 @@ module Library =
         (axiom: Axiom)
         : Rule seq =
         match axiom with
-        | AxiomObjectPropertyAxiom propertyAxiom -> ObjectPropertyAxiom2Datalog resourceMap resources propertyAxiom
+        | AxiomObjectPropertyAxiom propertyAxiom -> ObjectPropertyAxiom2Datalog logger resourceMap resources propertyAxiom
         | AxiomClassAxiom classAxiom ->
             match DagSemTools.ELI.Library.Owl2Datalog logger resources classAxiom with
             | Some rules -> rules

--- a/src/OWL2RL2Datalog/Library.fs
+++ b/src/OWL2RL2Datalog/Library.fs
@@ -39,7 +39,7 @@ module Library =
                       Predicate = Term.Resource (resources.AddNodeResource(AnonymousBlankNode bNode))
                       Object = Term.Variable "y" } |> Some
         | InverseObjectProperty innerObjProp ->
-                    getObjectPropertyExpressionResource logger resources objProp
+                    getObjectPropertyExpressionResource logger resources innerObjProp
                     |> Option.map (fun innerPattern ->
                     { TriplePattern.Subject = innerPattern.Object
                       Predicate = innerPattern.Predicate

--- a/src/RdfOwlTranslator/ClassExpressionParser.fs
+++ b/src/RdfOwlTranslator/ClassExpressionParser.fs
@@ -29,7 +29,7 @@ type ClassExpressionParser (triples : TripleTable,
     let resources = resourceManager
 
     let rdfTypeId = resources.AddNodeResource(RdfResource.Iri (new IriReference(RdfType)))
-    let rdfLiteralId = resources.AddNodeResource(RdfResource.Iri (new IriReference(RdfLiteral)))
+    let rdfsLiteralId = resources.AddNodeResource(RdfResource.Iri (new IriReference(RdfsLiteral)))
     let owlOntologyId = resources.AddNodeResource(RdfResource.Iri(new IriReference(OwlOntology)))
     let versionPropId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlVersionIri)))
     let importsPropId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlImport)))
@@ -116,7 +116,7 @@ type ClassExpressionParser (triples : TripleTable,
                                                 |> Option.map (fun iri -> (id, iri)))
     
     let getHardcodedDatarangeDeclarations   =
-        [rdfLiteralId]
+        [rdfsLiteralId]
         |> Seq.choose (fun id -> resources.GetNamedResource id |> Option.map Iri.FullIri 
                                                 |> Option.map (fun iri -> (id, iri)))
     

--- a/src/RdfOwlTranslator/ClassExpressionParser.fs
+++ b/src/RdfOwlTranslator/ClassExpressionParser.fs
@@ -29,6 +29,7 @@ type ClassExpressionParser (triples : TripleTable,
     let resources = resourceManager
 
     let rdfTypeId = resources.AddNodeResource(RdfResource.Iri (new IriReference(RdfType)))
+    let rdfLiteralId = resources.AddNodeResource(RdfResource.Iri (new IriReference(RdfLiteral)))
     let owlOntologyId = resources.AddNodeResource(RdfResource.Iri(new IriReference(OwlOntology)))
     let versionPropId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlVersionIri)))
     let importsPropId = resources.AddNodeResource(RdfResource.Iri (new IriReference(OwlImport)))
@@ -113,6 +114,12 @@ type ClassExpressionParser (triples : TripleTable,
         Seq.concat [getBasicDeclarations typeId; getAxiomDeclarations typeId]
         |> Seq.choose (fun id -> resources.GetNamedResource id |> Option.map Iri.FullIri 
                                                 |> Option.map (fun iri -> (id, iri)))
+    
+    let getHardcodedDatarangeDeclarations   =
+        [rdfLiteralId]
+        |> Seq.choose (fun id -> resources.GetNamedResource id |> Option.map Iri.FullIri 
+                                                |> Option.map (fun iri -> (id, iri)))
+    
                                                 
     (* CE *)
     let mutable ClassExpressions : Map<GraphElementId, ClassExpression> =
@@ -127,7 +134,7 @@ type ClassExpressionParser (triples : TripleTable,
     
     (* DR *)
     let mutable DataRanges : Map<GraphElementId, DataRange> =
-        getInitialDeclarations RdfsDatatype
+        Seq.concat [getHardcodedDatarangeDeclarations; getInitialDeclarations RdfsDatatype]
         |> Seq.map (fun (id, iri) ->  (id, NamedDataRange iri))
         |> Map.ofSeq
     (* OPE *)

--- a/src/Turtle.Parser/IriGrammarVisitor.cs
+++ b/src/Turtle.Parser/IriGrammarVisitor.cs
@@ -77,11 +77,35 @@ public class IriGrammarVisitor : TurtleDocBaseVisitor<IriReference>
         var prefix = components[0];
         if (!_prefixes.TryGetValue(prefix, out var namespaceName))
             throw new Exception($"Prefix {prefix} is not defined.");
-        var localName = components[1];
+        var localName = components.Length > 1 ? (components[1] ?? "") : string.Empty;
         var iriString = $"{namespaceName}{localName}";
         return new IriReference(iriString);
     }
 
+    // Assumes input ends with colon, and removes it
+    private string RemoveTrailingColon(string input)
+    {
+        if (string.IsNullOrEmpty(input) || !input.EndsWith(":"))
+        {
+            throw new ArgumentException("The input string must end with a colon.");
+        }
+
+        return input.TrimEnd(':');
+    }
+    
+    /// <summary>
+    /// Visits an IRI which is just the prefix, f.ex. ex: or rdfs:
+    /// </summary>
+    /// <param name="ctxt"></param>
+    /// <returns></returns>
+    public override IriReference VisitIriPrefix(IriPrefixContext ctxt)
+    {
+        var iriString = ctxt.PNAME_NS().GetText();
+        var prefix = RemoveTrailingColon(iriString);
+        if (!_prefixes.TryGetValue(prefix, out var namespaceName))
+            throw new Exception($"Prefix {prefix} is not defined.");
+        return namespaceName;
+    }
     /// <summary>
     /// Visits a relative IRI in angled brackets, f.ex. &lt;../relative&gt;
     /// </summary>

--- a/src/Turtle.Parser/IriGrammarVisitor.cs
+++ b/src/Turtle.Parser/IriGrammarVisitor.cs
@@ -77,7 +77,7 @@ public class IriGrammarVisitor : TurtleDocBaseVisitor<IriReference>
         var prefix = components[0];
         if (!_prefixes.TryGetValue(prefix, out var namespaceName))
             throw new Exception($"Prefix {prefix} is not defined.");
-        var localName = components.Length > 1 ? (components[1] ?? "") : string.Empty;
+        var localName = components[1];
         var iriString = $"{namespaceName}{localName}";
         return new IriReference(iriString);
     }
@@ -92,7 +92,7 @@ public class IriGrammarVisitor : TurtleDocBaseVisitor<IriReference>
 
         return input.TrimEnd(':');
     }
-    
+
     /// <summary>
     /// Visits an IRI which is just the prefix, f.ex. ex: or rdfs:
     /// </summary>

--- a/src/Turtle.Parser/ResourceVisitor.cs
+++ b/src/Turtle.Parser/ResourceVisitor.cs
@@ -43,9 +43,16 @@ internal class ResourceVisitor : TurtleDocBaseVisitor<uint>
     /// <returns></returns>
     public override uint VisitIri(IriContext ctxt)
     {
-        var iri = _iriGrammarVisitor.VisitIri(ctxt)
-                  ?? throw new System.Exception($"Assumed IRI in {ctxt.GetText()} at line {ctxt.exception} is null");
-        return GetIriId(iri);
+        try
+        {
+            var iri = _iriGrammarVisitor.VisitIri(ctxt)
+                      ?? throw new System.Exception($"Assumed IRI in {ctxt.GetText()} at line {ctxt.Start.Line}, position {ctxt.Start.Column} is null");
+            return GetIriId(iri);
+        }
+        catch (Exception ex)
+        {
+            throw new Exception($"Error visiting IRI at line {ctxt.Start.Line}, position {ctxt.Start.Column}: {ex.Message}", ex);
+        }
     }
 
     /// <summary>

--- a/test/Api.Tests/TestApiOntology.cs
+++ b/test/Api.Tests/TestApiOntology.cs
@@ -183,7 +183,7 @@ public class TestApiOntology(ITestOutputHelper output)
 
 
 
-    [Fact(Skip = "See https://github.com/daghovland/DagSemTools/issues/60")]
+    [Fact]
     public void LoadIDOOntologyWorks()
     {
         var ontologyFileInfo = new FileInfo("TestData/LIS-14.ttl");

--- a/test/TurtleParser.Unit.Tests/TestData/onlyPrefixIri.ttl
+++ b/test/TurtleParser.Unit.Tests/TestData/onlyPrefixIri.ttl
@@ -1,0 +1,3 @@
+@prefix test: <https://example.com/test#>
+
+test:ex test:definedBy test: .

--- a/test/TurtleParser.Unit.Tests/TestParser.cs
+++ b/test/TurtleParser.Unit.Tests/TestParser.cs
@@ -215,6 +215,13 @@ public class TestParser : IDisposable, IAsyncDisposable
         Assert.NotNull(ont);
     }
 
+    [Fact]
+    public void TestOnlyPrefixIri()
+    {
+        var ontology = File.ReadAllText("TestData/onlyPrefixIri.ttl");
+        var ont = TestOntology(ontology);
+        Assert.NotNull(ont);
+    }
 
     [Fact]
     public void TestQuotedLiterals()

--- a/test/TurtleParser.Unit.Tests/TurtleParser.Unit.Tests.csproj
+++ b/test/TurtleParser.Unit.Tests/TurtleParser.Unit.Tests.csproj
@@ -99,6 +99,9 @@
       <None Update="TestData\example27.ttl">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
+      <None Update="TestData\onlyPrefixIri.ttl">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
* Fixed bug in turtle parser that did not handle Iris witout a localname (the visitor method was lacking)
* Added lacking methods/handling of complex domains and ranges in the translator from owl to datalog
* Changed several exceptions into warnings that were about non-RL axioms. 