### PR TITLE
nuget package upgrades

### DIFF
--- a/src/AlcTableau/AlcTableau.fsproj
+++ b/src/AlcTableau/AlcTableau.fsproj
@@ -43,8 +43,8 @@
 
     <ItemGroup>
       <PackageReference Include="IriTools" Version="2.2.0" />
-      <PackageReference Update="FSharp.Core" Version="8.0.403" />
-      <PackageReference Include="Serilog" Version="4.2.0" />
+      <PackageReference Update="FSharp.Core" Version="9.0.303" />
+      <PackageReference Include="Serilog" Version="4.3.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -50,10 +50,10 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="FSharp.Core" Version="8.0.403" />
+        <PackageReference Include="FSharp.Core" Version="9.0.303" />
         <PackageReference Include="IriTools" Version="2.2.0" />
         <PackageReference Include="LanguageExt.Core" Version="4.4.9" />
-        <PackageReference Include="Serilog" Version="4.2.0" />
+        <PackageReference Include="Serilog" Version="4.3.0" />
     </ItemGroup>    
     
     <ItemGroup>

--- a/src/Datalog.Parser/Datalog.Parser.csproj
+++ b/src/Datalog.Parser/Datalog.Parser.csproj
@@ -26,9 +26,9 @@
     <ItemGroup>
         <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
         <PackageReference Include="Antlr4BuildTasks" Version="12.10.0" />
-        <PackageReference Include="FSharp.Core" Version="8.0.403" />
-        <PackageReference Include="Microsoft.Build.Framework" Version="17.12.6" />
-        <PackageReference Include="Serilog" Version="4.2.0" />
+        <PackageReference Include="FSharp.Core" Version="9.0.303" />
+        <PackageReference Include="Microsoft.Build.Framework" Version="17.14.8" />
+        <PackageReference Include="Serilog" Version="4.3.0" />
     </ItemGroup>
     <ItemGroup>
         <Antlr4 Include="grammars\Datalog.g4">

--- a/src/Datalog/Datalog.fsproj
+++ b/src/Datalog/Datalog.fsproj
@@ -61,9 +61,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Update="FSharp.Core" Version="8.0.403" />
+      <PackageReference Update="FSharp.Core" Version="9.0.303" />
       <PackageReference Include="IriTools" Version="2.2.0" />
-        <PackageReference Include="Serilog" Version="4.2.0" />
+        <PackageReference Include="Serilog" Version="4.3.0" />
     </ItemGroup>
         
     <ItemGroup>

--- a/src/ELI/ELI.fsproj
+++ b/src/ELI/ELI.fsproj
@@ -55,9 +55,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Update="FSharp.Core" Version="8.0.403" />
+        <PackageReference Update="FSharp.Core" Version="9.0.303" />
         <PackageReference Include="IriTools" Version="2.2.0" />
-        <PackageReference Include="Serilog" Version="4.2.0" />
+        <PackageReference Include="Serilog" Version="4.3.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     </ItemGroup>
     

--- a/src/Ingress/Ingress.fsproj
+++ b/src/Ingress/Ingress.fsproj
@@ -38,10 +38,10 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Antlr4BuildTasks" Version="12.10.0" />
-        <PackageReference Include="Faqt" Version="4.5.0" />
+        <PackageReference Include="Faqt" Version="5.1.0" />
         <PackageReference Include="IriTools" Version="2.2.0" />
-        <PackageReference Update="FSharp.Core" Version="8.0.403" />
-        <PackageReference Include="Serilog" Version="4.2.0" />
+        <PackageReference Update="FSharp.Core" Version="9.0.303" />
+        <PackageReference Include="Serilog" Version="4.3.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/Manchester.Parser/Manchester.Parser.csproj
+++ b/src/Manchester.Parser/Manchester.Parser.csproj
@@ -34,9 +34,9 @@
   <ItemGroup>
 		<PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
 		<PackageReference Include="Antlr4BuildTasks" Version="12.10.0" />
-    <PackageReference Include="FSharp.Core" Version="8.0.403" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="17.12.6" />
-    <PackageReference Include="Serilog" Version="4.2.0" />
+    <PackageReference Include="FSharp.Core" Version="9.0.303" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="17.14.8" />
+    <PackageReference Include="Serilog" Version="4.3.0" />
 	</ItemGroup>
 	<ItemGroup>
         <Antlr4 Include="grammars/IriGrammar.g4">

--- a/src/Manchester/Manchester.fsproj
+++ b/src/Manchester/Manchester.fsproj
@@ -30,9 +30,9 @@
         </Content>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Update="FSharp.Core" Version="8.0.403" />
+        <PackageReference Update="FSharp.Core" Version="9.0.303" />
         <PackageReference Include="IriTools" Version="2.2.0" />
-        <PackageReference Include="Serilog" Version="4.2.0" />
+        <PackageReference Include="Serilog" Version="4.3.0" />
     </ItemGroup>
     
     <ItemGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/OWL2ALC/OWL2ALC.fsproj
+++ b/src/OWL2ALC/OWL2ALC.fsproj
@@ -35,10 +35,10 @@
 
     <ItemGroup>
         <PackageReference Include="Antlr4BuildTasks" Version="12.10.0" />
-        <PackageReference Include="Faqt" Version="4.5.0" />
-        <PackageReference Update="FSharp.Core" Version="8.0.403" />
+        <PackageReference Include="Faqt" Version="5.1.0" />
+        <PackageReference Update="FSharp.Core" Version="9.0.303" />
         <PackageReference Include="IriTools" Version="2.2.0" />
-        <PackageReference Include="Serilog" Version="4.2.0" />
+        <PackageReference Include="Serilog" Version="4.3.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/OWL2RL2Datalog/OWL2RL2Datalog.fsproj
+++ b/src/OWL2RL2Datalog/OWL2RL2Datalog.fsproj
@@ -37,10 +37,10 @@
 
     <ItemGroup>
         <PackageReference Include="Antlr4BuildTasks" Version="12.10.0" />
-        <PackageReference Include="Faqt" Version="4.5.0" />
-        <PackageReference Update="FSharp.Core" Version="8.0.403" />
+        <PackageReference Include="Faqt" Version="5.1.0" />
+        <PackageReference Update="FSharp.Core" Version="9.0.303" />
         <PackageReference Include="IriTools" Version="2.2.0" />
-        <PackageReference Include="Serilog" Version="4.2.0" />
+        <PackageReference Include="Serilog" Version="4.3.0" />
     </ItemGroup>
     
     <ItemGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/OwlOntology/OwlOntology.fsproj
+++ b/src/OwlOntology/OwlOntology.fsproj
@@ -37,8 +37,8 @@
     
     <ItemGroup>
         <PackageReference Include="IriTools" Version="2.2.0" />
-        <PackageReference Update="FSharp.Core" Version="8.0.403" />
-        <PackageReference Include="Serilog" Version="4.2.0" />
+        <PackageReference Update="FSharp.Core" Version="9.0.303" />
+        <PackageReference Include="Serilog" Version="4.3.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/Parser/Parser.csproj
+++ b/src/Parser/Parser.csproj
@@ -26,7 +26,7 @@
 
     <ItemGroup>
       <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
-      <PackageReference Include="Serilog" Version="4.2.0" />
+      <PackageReference Include="Serilog" Version="4.3.0" />
     </ItemGroup>
     <ItemGroup>
         <InternalsVisibleTo Include="DagSemTools.Sparql.Parser" />

--- a/src/Rdf/Rdf.fsproj
+++ b/src/Rdf/Rdf.fsproj
@@ -39,8 +39,8 @@
 
     <ItemGroup>
         <PackageReference Include="IriTools" Version="2.2.0" />
-        <PackageReference Update="FSharp.Core" Version="8.0.403" />
-        <PackageReference Include="Serilog" Version="4.2.0" />
+        <PackageReference Update="FSharp.Core" Version="9.0.303" />
+        <PackageReference Include="Serilog" Version="4.3.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/RdfOwlTranslator/RdfOwlTranslator.fsproj
+++ b/src/RdfOwlTranslator/RdfOwlTranslator.fsproj
@@ -39,8 +39,8 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="IriTools" Version="2.2.0" />
-        <PackageReference Update="FSharp.Core" Version="8.0.403" />
-        <PackageReference Include="Serilog" Version="4.2.0" />
+        <PackageReference Update="FSharp.Core" Version="9.0.303" />
+        <PackageReference Include="Serilog" Version="4.3.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/Sparql.Parser/Sparql.Parser.csproj
+++ b/src/Sparql.Parser/Sparql.Parser.csproj
@@ -28,9 +28,9 @@
     <ItemGroup>
         <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
         <PackageReference Include="Antlr4BuildTasks" Version="12.10.0" />
-        <PackageReference Include="FSharp.Core" Version="8.0.403" />
-        <PackageReference Include="Microsoft.Build.Framework" Version="17.12.6" />
-        <PackageReference Include="Serilog" Version="4.2.0" />
+        <PackageReference Include="FSharp.Core" Version="9.0.303" />
+        <PackageReference Include="Microsoft.Build.Framework" Version="17.14.8" />
+        <PackageReference Include="Serilog" Version="4.3.0" />
     </ItemGroup>
     <ItemGroup>
         <None Update="grammars\SparqlTokens.g4" >

--- a/src/TestUtils/TestUtils.csproj
+++ b/src/TestUtils/TestUtils.csproj
@@ -14,7 +14,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Serilog" Version="4.2.0" />
+      <PackageReference Include="Serilog" Version="4.3.0" />
       <PackageReference Include="xunit" Version="2.9.3" />
       <PackageReference Include="xunit.abstractions" Version="2.0.3" />
     </ItemGroup>

--- a/src/Turtle.Parser/Turtle.Parser.csproj
+++ b/src/Turtle.Parser/Turtle.Parser.csproj
@@ -27,9 +27,9 @@
 	<ItemGroup>
 		<PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
 		<PackageReference Include="Antlr4BuildTasks" Version="12.10.0" />
-        <PackageReference Include="FSharp.Core" Version="8.0.403" />
-        <PackageReference Include="Microsoft.Build.Framework" Version="17.12.6" />
-        <PackageReference Include="Serilog" Version="4.2.0" />
+        <PackageReference Include="FSharp.Core" Version="9.0.303" />
+        <PackageReference Include="Microsoft.Build.Framework" Version="17.14.8" />
+        <PackageReference Include="Serilog" Version="4.3.0" />
     </ItemGroup>
     <ItemGroup>
         <None Update="grammars\TurtleResource.g4">

--- a/test/AlcTest/AlcTest.fsproj
+++ b/test/AlcTest/AlcTest.fsproj
@@ -20,16 +20,16 @@
 
     <ItemGroup>
         <PackageReference Include="Antlr4BuildTasks" Version="12.10.0" />
-        <PackageReference Include="Faqt" Version="4.5.0" />
+        <PackageReference Include="Faqt" Version="5.1.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-        <PackageReference Include="Serilog" Version="4.2.0" />
-        <PackageReference Include="Serilog.Sinks.InMemory" Version="0.15.0" />
+        <PackageReference Include="Serilog" Version="4.3.0" />
+        <PackageReference Include="Serilog.Sinks.InMemory" Version="2.0.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Update="FSharp.Core" Version="8.0.403" />
+        <PackageReference Update="FSharp.Core" Version="9.0.303" />
         <PackageReference Include="IriTools" Version="2.2.0" />
         <PackageReference Include="xunit.abstractions" Version="2.0.3" />
     </ItemGroup>

--- a/test/Api.Tests/Api.Tests.csproj
+++ b/test/Api.Tests/Api.Tests.csproj
@@ -12,12 +12,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="7.0.0" />
+        <PackageReference Include="FluentAssertions" Version="8.7.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-        <PackageReference Include="Serilog" Version="4.2.0" />
-        <PackageReference Include="Serilog.Sinks.InMemory" Version="0.15.0" />
+        <PackageReference Include="Serilog" Version="4.3.0" />
+        <PackageReference Include="Serilog.Sinks.InMemory" Version="2.0.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/test/Datalog.Test/Datalog.Test.fsproj
+++ b/test/Datalog.Test/Datalog.Test.fsproj
@@ -19,13 +19,13 @@
 
     <ItemGroup>
         <PackageReference Include="Antlr4BuildTasks" Version="12.10.0" />
-        <PackageReference Include="Faqt" Version="4.5.0" />
+        <PackageReference Include="Faqt" Version="5.1.0" />
         <PackageReference Include="IriTools" Version="2.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-        <PackageReference Include="Serilog" Version="4.2.0" />
-        <PackageReference Include="Serilog.Sinks.InMemory" Version="0.15.0" />
+        <PackageReference Include="Serilog" Version="4.3.0" />
+        <PackageReference Include="Serilog.Sinks.InMemory" Version="2.0.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
@@ -33,7 +33,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Update="FSharp.Core" Version="8.0.403" />
+        <PackageReference Update="FSharp.Core" Version="9.0.303" />
     </ItemGroup>
 
     <!-- Use project references for local development -->

--- a/test/DatalogParser.Unit.Tests/DatalogParser.Unit.Tests.csproj
+++ b/test/DatalogParser.Unit.Tests/DatalogParser.Unit.Tests.csproj
@@ -12,12 +12,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="7.0.0" />
+        <PackageReference Include="FluentAssertions" Version="8.7.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-        <PackageReference Include="Serilog" Version="4.2.0" />
-        <PackageReference Include="Serilog.Sinks.InMemory" Version="0.15.0" />
+        <PackageReference Include="Serilog" Version="4.3.0" />
+        <PackageReference Include="Serilog.Sinks.InMemory" Version="2.0.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/test/ELI.Tests/ELI.Tests.fsproj
+++ b/test/ELI.Tests/ELI.Tests.fsproj
@@ -15,12 +15,12 @@
 
     <ItemGroup>
         <PackageReference Include="Antlr4BuildTasks" Version="12.10.0" />
-        <PackageReference Include="Faqt" Version="4.5.0" />
+        <PackageReference Include="Faqt" Version="5.1.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-        <PackageReference Include="Serilog" Version="4.2.0" />
-        <PackageReference Include="Serilog.Sinks.InMemory" Version="0.15.0" />
+        <PackageReference Include="Serilog" Version="4.3.0" />
+        <PackageReference Include="Serilog.Sinks.InMemory" Version="2.0.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
@@ -28,7 +28,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Update="FSharp.Core" Version="8.0.403" />
+        <PackageReference Update="FSharp.Core" Version="9.0.303" />
     </ItemGroup>
 
     

--- a/test/Ingress.Tests/Ingress.Tests.fsproj
+++ b/test/Ingress.Tests/Ingress.Tests.fsproj
@@ -13,10 +13,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0"/>
-        <PackageReference Include="Serilog.Sinks.InMemory" Version="0.15.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0"/>
+        <PackageReference Include="Serilog.Sinks.InMemory" Version="2.0.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/test/Manchester2Alc.Tests/Manchester2Alc.Tests.csproj
+++ b/test/Manchester2Alc.Tests/Manchester2Alc.Tests.csproj
@@ -23,18 +23,18 @@
     </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
-    <PackageReference Include="FSharp.Core" Version="8.0.403" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="17.12.6" />
+    <PackageReference Include="FluentAssertions" Version="8.7.1" />
+    <PackageReference Include="FSharp.Core" Version="9.0.303" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="17.14.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Serilog" Version="4.2.0" />
+    <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-    <PackageReference Include="Serilog.Sinks.InMemory" Version="0.15.0" />
+    <PackageReference Include="Serilog.Sinks.InMemory" Version="2.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
     <PackageReference Include="Antlr4BuildTasks" Version="12.10.0" />
     <PackageReference Include="IriTools" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/ManchesterAntlr.Unit.Tests/ManchesterAntlr.Unit.Tests.csproj
+++ b/test/ManchesterAntlr.Unit.Tests/ManchesterAntlr.Unit.Tests.csproj
@@ -23,18 +23,18 @@
     </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
-    <PackageReference Include="FSharp.Core" Version="8.0.403" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="17.12.6" />
+    <PackageReference Include="FluentAssertions" Version="8.7.1" />
+    <PackageReference Include="FSharp.Core" Version="9.0.303" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="17.14.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Serilog" Version="4.2.0" />
+    <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-    <PackageReference Include="Serilog.Sinks.InMemory" Version="0.15.0" />
+    <PackageReference Include="Serilog.Sinks.InMemory" Version="2.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
     <PackageReference Include="Antlr4BuildTasks" Version="12.10.0" />
     <PackageReference Include="IriTools" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/OWL2ALC.Tests/OWL2ALC.Tests.fsproj
+++ b/test/OWL2ALC.Tests/OWL2ALC.Tests.fsproj
@@ -16,10 +16,10 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-        <PackageReference Include="Serilog" Version="4.2.0" />
-        <PackageReference Include="Serilog.Sinks.InMemory" Version="0.15.0" />
+        <PackageReference Include="Serilog" Version="4.3.0" />
+        <PackageReference Include="Serilog.Sinks.InMemory" Version="2.0.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
@@ -27,7 +27,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Update="FSharp.Core" Version="8.0.403" />
+        <PackageReference Update="FSharp.Core" Version="9.0.303" />
     </ItemGroup>
 
     <!-- Use project references for local development -->

--- a/test/OWL2RL2Datalog.Tests/OWL2RL2Datalog.Tests.fsproj
+++ b/test/OWL2RL2Datalog.Tests/OWL2RL2Datalog.Tests.fsproj
@@ -17,10 +17,10 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-        <PackageReference Include="Serilog" Version="4.2.0" />
-        <PackageReference Include="Serilog.Sinks.InMemory" Version="0.15.0" />
+        <PackageReference Include="Serilog" Version="4.3.0" />
+        <PackageReference Include="Serilog.Sinks.InMemory" Version="2.0.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
@@ -28,7 +28,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Update="FSharp.Core" Version="8.0.403" />
+        <PackageReference Update="FSharp.Core" Version="9.0.303" />
     </ItemGroup>
 
     <!-- Use project references for local development -->

--- a/test/Rdf.Unit.Tests/Rdf.Unit.Tests.fsproj
+++ b/test/Rdf.Unit.Tests/Rdf.Unit.Tests.fsproj
@@ -17,16 +17,16 @@
 
     <ItemGroup>
         <PackageReference Include="Antlr4BuildTasks" Version="12.10.0" />
-        <PackageReference Include="Faqt" Version="4.5.0" />
+        <PackageReference Include="Faqt" Version="5.1.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-        <PackageReference Include="Serilog" Version="4.2.0" />
+        <PackageReference Include="Serilog" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.abstractions" Version="2.0.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Update="FSharp.Core" Version="8.0.403" />
+        <PackageReference Update="FSharp.Core" Version="9.0.303" />
     </ItemGroup>
 
     <!-- Use project references for local development -->

--- a/test/RdfOwlTranslator.Tests/RdfOwlTranslator.Tests.fsproj
+++ b/test/RdfOwlTranslator.Tests/RdfOwlTranslator.Tests.fsproj
@@ -15,12 +15,12 @@
 
     <ItemGroup>
         <PackageReference Include="Antlr4BuildTasks" Version="12.10.0" />
-        <PackageReference Include="Faqt" Version="4.5.0" />
+        <PackageReference Include="Faqt" Version="5.1.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-        <PackageReference Include="Serilog" Version="4.2.0" />
-        <PackageReference Include="Serilog.Sinks.InMemory" Version="0.15.0" />
+        <PackageReference Include="Serilog" Version="4.3.0" />
+        <PackageReference Include="Serilog.Sinks.InMemory" Version="2.0.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
@@ -28,7 +28,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Update="FSharp.Core" Version="8.0.403" />
+        <PackageReference Update="FSharp.Core" Version="9.0.303" />
     </ItemGroup>
     
     <!-- Use project references for local development -->

--- a/test/Reasoner.Integration.Tests/Reasoner.Integration.Tests.fsproj
+++ b/test/Reasoner.Integration.Tests/Reasoner.Integration.Tests.fsproj
@@ -47,15 +47,15 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-        <PackageReference Include="Serilog" Version="4.2.0" />
-        <PackageReference Include="Serilog.Sinks.InMemory" Version="0.15.0" />
+        <PackageReference Include="Serilog" Version="4.3.0" />
+        <PackageReference Include="Serilog.Sinks.InMemory" Version="2.0.0" />
         
         <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Update="FSharp.Core" Version="8.0.403" />
+        <PackageReference Update="FSharp.Core" Version="9.0.303" />
     </ItemGroup>
 
     <!-- Use project references for local development -->

--- a/test/Sparql.Parser.Tests/Sparql.Parser.Tests.csproj
+++ b/test/Sparql.Parser.Tests/Sparql.Parser.Tests.csproj
@@ -12,19 +12,19 @@
 
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Build.Framework" Version="17.12.6" />
+        <PackageReference Include="Microsoft.Build.Framework" Version="17.14.8" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-        <PackageReference Include="Serilog" Version="4.2.0" />
+        <PackageReference Include="Serilog" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="7.0.0" />
+        <PackageReference Include="FluentAssertions" Version="8.7.1" />
         <PackageReference Include="IriTools" Version="2.2.0" />
         <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
         <PackageReference Include="Antlr4BuildTasks" Version="12.10.0" />
-        <PackageReference Include="FSharp.Core" Version="8.0.403" />
+        <PackageReference Include="FSharp.Core" Version="9.0.303" />
     </ItemGroup>
 
 

--- a/test/TurtleParser.Unit.Tests/TestParser.cs
+++ b/test/TurtleParser.Unit.Tests/TestParser.cs
@@ -139,8 +139,8 @@ public class TestParser : IDisposable, IAsyncDisposable
                                p:subject4 p:predicate4 p:object4 .     # prefixed name, e.g., http://one.example/path/subject4
                                """);
         ont.Triples.TripleCount.Should().Be(1);
-        ont.Triples.GetTriples().First().subject.Should().BeGreaterOrEqualTo(0);
-        ont.Triples.GetTriples().First().predicate.Should().BeGreaterOrEqualTo(0);
+        ont.Triples.GetTriples().First().subject.Should().BeGreaterThanOrEqualTo(0);
+        ont.Triples.GetTriples().First().predicate.Should().BeGreaterThanOrEqualTo(0);
     }
 
     [Fact]
@@ -179,9 +179,9 @@ public class TestParser : IDisposable, IAsyncDisposable
         Assert.NotNull(ont);
         ont.Triples.TripleCount.Should().Be(1);
         var triple = ont.Triples.GetTriples().First();
-        triple.subject.Should().BeGreaterOrEqualTo(0);
-        triple.predicate.Should().BeGreaterOrEqualTo(0);
-        triple.obj.Should().BeGreaterOrEqualTo(0);
+        triple.subject.Should().BeGreaterThanOrEqualTo(0);
+        triple.predicate.Should().BeGreaterThanOrEqualTo(0);
+        triple.obj.Should().BeGreaterThanOrEqualTo(0);
     }
 
     [Fact]

--- a/test/TurtleParser.Unit.Tests/TurtleParser.Unit.Tests.csproj
+++ b/test/TurtleParser.Unit.Tests/TurtleParser.Unit.Tests.csproj
@@ -12,19 +12,19 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Build.Framework" Version="17.12.6" />
+        <PackageReference Include="Microsoft.Build.Framework" Version="17.14.8" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-        <PackageReference Include="Serilog" Version="4.2.0" />
+        <PackageReference Include="Serilog" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="7.0.0" />
+        <PackageReference Include="FluentAssertions" Version="8.7.1" />
         <PackageReference Include="IriTools" Version="2.2.0" />
         <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
         <PackageReference Include="Antlr4BuildTasks" Version="12.10.0" />
-        <PackageReference Include="FSharp.Core" Version="8.0.403" />
+        <PackageReference Include="FSharp.Core" Version="9.0.303" />
     </ItemGroup>
 
 


### PR DESCRIPTION
I upgraded all nuget packages. Including fsharp 8 to 9 and several test libraries. FLuentAssertions is not anymore Apache-licensed, but for this open source project the license seems to be good