### PR TITLE
Comprehensive SPARQL tests

### DIFF
--- a/.github/llm-context.md
+++ b/.github/llm-context.md
@@ -10,30 +10,33 @@
 
 ## Current Focus
 - SPARQL query support expansion (check story/sparql-tests branch)
+- Datalog engine extension with similar functions as SPARQL. Ideally similar implementation as for SPARQL
+- Speed of Rdf parsing and parsing Rdf to Owl
 - Parser correctness vs W3C specs
 
 ## When Working on Parsers
-1. Grammar files in grammars/ are source of truth
+1. Grammar files in grammars/ are source of truth. The grammar files in the individual projects are softlinks to the top-level grammar directory
 2. Regenerate parser: `antlr4 -Dlanguage=CSharp -visitor grammar.g4`
-3. Update visitor classes in corresponding parser project
+3. Update visitor and/or listener classes in corresponding parser project
 4. Add test cases covering new syntax
 
 ## Common Pitfalls
 - SPARQL injection: no built-in protection currently
 - Stratification required for Datalog with negation
-- Only OWL 2 DL subset supported (no annotation axioms)
 
 ## Code Navigation Tips
-- **Graph implementation**: src/Api/Graph.cs
-- **SPARQL query evaluation**: src/Api/SparqlQueryEvaluator.cs
-- **Datalog engine**: src/Api/Datalog/
+- **Client-facing API**: src/Api
+- **Graph implementation**: src/Rdf/QuadTable.fs
+- **SPARQL query evaluation**: src/Rdf/QueryProcessor.fs
+- **Datalog engine**: src/Datalog/
 - **Parser visitors**: src/*/Visitor.cs files
+- **Parser listeners**: src/*/Listener.cs files
 
 ## Supported Features
 ### RDF/Turtle
 - ✅ Turtle 1.2
 - ✅ TriG (named graphs)
-- ✅ Basic triple patterns
+- ✅ Blank nodes
 
 ### SPARQL
 - ✅ SELECT queries
@@ -45,12 +48,11 @@
 
 ### OWL
 - ✅ Manchester syntax
-- ✅ OWL 2 DL subset
-- ✅ OWL 2 RL reasoning
-- ❌ Annotation axioms
+- ✅ Rdf syntax (Parser from Rdf to Owl in src/RdfOwlTransator)
+- ✅ OWL 2 RL subset supported with rule-based reasoning (Parser from Owl to Datalog in src/OWL2RL2Datalog)
+- ✅ The most basic Tableau-based reasoning in src/AlcTableau supporting acyclic ALC ontologies
 
 ### Datalog
-- ✅ Stratifiable programs
-- ✅ Negation (with stratification)
-- ✅ Recursion
+- ✅ Supports negation and recursion of stratifiable datalog programs
+- ✅ Rule engine in src/Datalog/Reasoner.fs
 - ❌ Built-in functions beyond triples

--- a/.github/llm-context.md
+++ b/.github/llm-context.md
@@ -1,0 +1,56 @@
+# LLM Development Context
+
+## Quick Start for AI Assistants
+1. This is a C# and F# semantic web library targeting .NET 10
+2. The intention is to create a correct and fast library for handling RDF in .NET projects
+2. The reasoner and other core functionality is implemented in F#, while the parser and the client-facing API in src/Api is in C#
+2. Build: `dotnet build`
+3. Test: `dotnet test` (requires test data setup - see BUILDING.md)
+4. Main areas: RDF parsing, SPARQL, OWL reasoning, Datalog
+
+## Current Focus
+- SPARQL query support expansion (check story/sparql-tests branch)
+- Parser correctness vs W3C specs
+
+## When Working on Parsers
+1. Grammar files in grammars/ are source of truth
+2. Regenerate parser: `antlr4 -Dlanguage=CSharp -visitor grammar.g4`
+3. Update visitor classes in corresponding parser project
+4. Add test cases covering new syntax
+
+## Common Pitfalls
+- SPARQL injection: no built-in protection currently
+- Stratification required for Datalog with negation
+- Only OWL 2 DL subset supported (no annotation axioms)
+
+## Code Navigation Tips
+- **Graph implementation**: src/Api/Graph.cs
+- **SPARQL query evaluation**: src/Api/SparqlQueryEvaluator.cs
+- **Datalog engine**: src/Api/Datalog/
+- **Parser visitors**: src/*/Visitor.cs files
+
+## Supported Features
+### RDF/Turtle
+- ✅ Turtle 1.2
+- ✅ TriG (named graphs)
+- ✅ Basic triple patterns
+
+### SPARQL
+- ✅ SELECT queries
+- ✅ Basic graph patterns
+- ✅ Aggregate functions (recent addition)
+- ❌ CONSTRUCT/ASK/DESCRIBE
+- ❌ FILTER expressions
+- ❌ OPTIONAL patterns
+
+### OWL
+- ✅ Manchester syntax
+- ✅ OWL 2 DL subset
+- ✅ OWL 2 RL reasoning
+- ❌ Annotation axioms
+
+### Datalog
+- ✅ Stratifiable programs
+- ✅ Negation (with stratification)
+- ✅ Recursion
+- ❌ Built-in functions beyond triples

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,52 @@
+# Architecture Overview
+
+## Solution Structure
+```
+DagSemTools/
+├── src/
+│   ├── Api/              # Core RDF graph, reasoning engine
+│   ├── Parser/           # Base parser utilities
+│   ├── Turtle.Parser/    # Turtle/TriG parser
+│   ├── Manchester.Parser/# OWL Manchester syntax parser
+│   ├── Sparql.Parser/    # SPARQL query parser
+│   └── Datalog.Parser/   # Datalog rules parser
+├── test/                 # Unit and integration tests
+└── grammars/            # ANTLR grammar definitions
+```
+
+## Key Entry Points
+- **RDF Loading**: `TriGParser.Parse()` in Turtle.Parser
+- **SPARQL Queries**: `graph.AnswerSelectQuery()` in Api
+- **Reasoning**: `Ontology.create().GetAxiomRules()` in Api
+- **Datalog**: `graph.LoadDatalog()` in Api
+
+## Parser Architecture
+All parsers use ANTLR4:
+1. Grammar file (.g4) in grammars/
+2. Generated parser/lexer classes
+3. Visitor pattern for AST traversal
+4. Output: semantic objects in Api namespace
+
+## Data Flow
+```
+Input File (.ttl/.owl/.sparql)
+    ↓
+ANTLR Parser (grammars/)
+    ↓
+Visitor Pattern (src/*Parser/)
+    ↓
+Semantic Objects (src/Api/)
+    ↓
+Graph/Reasoning Engine
+```
+
+## Reasoning Layers
+1. **RDF Graph**: Base triple store with indexing
+2. **Datalog Engine**: Stratified evaluation with negation support
+3. **OWL 2 RL**: Compiled to Datalog rules
+4. **SPARQL**: Query evaluation over materialized graph
+
+## Test Strategy
+- **Unit Tests**: Individual parser components, grammar rules
+- **Integration Tests**: Large real-world ontologies (IMF, GO, LIS-14)
+- **Compliance**: W3C specification test suites where applicable

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,114 @@
+# Claude Code Development Guide
+
+## Project Summary
+DagSemTools is a .NET library for semantic web technologies (RDF, OWL, SPARQL, Datalog). All parsers are built using ANTLR4 grammars and must conform strictly to W3C specifications.
+
+## Quick Reference
+
+### Build & Test
+```bash
+dotnet build                    # Build solution
+dotnet test                     # Run all tests
+dotnet format                   # Format code
+```
+
+### Project Structure
+- `src/Api/` - Core RDF graph, reasoning engine, query evaluator
+- `src/*.Parser/` - ANTLR-based parsers (Turtle, Manchester, SPARQL, Datalog)
+- `grammars/` - ANTLR grammar definitions (.g4 files)
+- `test/` - Unit and integration tests
+
+### Key Files
+- Graph implementation: `src/Api/Graph.cs`
+- SPARQL evaluation: `src/Api/SparqlQueryEvaluator.cs`
+- Datalog engine: `src/Api/Datalog/`
+- Parser visitors: `src/*/Visitor.cs`
+
+## Development Workflow
+
+### When Modifying Parsers
+1. Update ANTLR grammar in `grammars/*.g4`
+2. Regenerate parser: `antlr4 -Dlanguage=CSharp -visitor <grammar>.g4`
+3. Update visitor class in corresponding `src/*.Parser/` project
+4. Add test cases in `test/*.Tests/`
+5. Run `dotnet test` to verify
+
+### When Adding Features
+1. Check W3C specification for correctness
+2. Add unit tests first (TDD approach)
+3. Implement in appropriate layer (parser → API → query evaluator)
+4. Test with real-world ontologies (IMF, Gene Ontology, LIS-14)
+
+### When Fixing Bugs
+1. Check if it's a grammar issue or visitor implementation
+2. Add regression test reproducing the bug
+3. Fix and verify all tests pass
+
+## Important Constraints
+
+### Supported Features
+- ✅ Turtle 1.2, TriG
+- ✅ SPARQL SELECT with basic graph patterns and aggregates
+- ✅ OWL 2 Manchester syntax (DL subset only)
+- ✅ Stratifiable Datalog with negation
+- ✅ OWL 2 RL reasoning
+
+### Not Supported
+- ❌ SPARQL CONSTRUCT/ASK/DESCRIBE, FILTER, OPTIONAL
+- ❌ OWL annotation axioms
+- ❌ Datalog built-in functions (only triples)
+- ❌ SPARQL injection protection
+
+## Testing Requirements
+- All parser changes need tests
+- Integration tests require external data (see BUILDING.md)
+- Test data setup:
+  ```bash
+  curl -o test/Api.Tests/TestData/imf.ttl http://ns.imfid.org/20240531/imf-ontology.owl.ttl
+  curl -o test/Api.Tests/TestData/go.owl.xml http://current.geneontology.org/ontology/go.owl
+  curl -o test/Api.Tests/TestData/LIS-14.ttl https://rds.posccaesar.org/ontology/lis14/ont/core/4.0/LIS-14.ttl
+  riot --output=TURTLE test/Api.Tests/TestData/go.owl.xml > test/Api.Tests/TestData/go.ttl
+  ```
+
+## Common Patterns
+
+### Loading RDF
+```csharp
+var file = new FileInfo("graph.ttl");
+var graph = TriGParser.Parse(file, Console.Error).GetDefaultGraph();
+```
+
+### Running SPARQL Queries
+```csharp
+var results = graph.AnswerSelectQuery("SELECT * WHERE {?s ?p ?o}");
+// Returns IEnumerable<Dictionary<string, GraphElement>>
+```
+
+### Loading Datalog Rules
+```csharp
+var datalogFile = new FileInfo("rules.datalog");
+graph.LoadDatalog(datalogFile);
+```
+
+### OWL Reasoning
+```csharp
+var ontology = Ontology.create(ontologyGraph);
+graph.LoadDatalog(ontology.GetAxiomRules());
+```
+
+## Code Conventions
+- Follow existing naming patterns in codebase
+- Parser visitors should handle all grammar rules
+- Error messages should reference W3C spec sections when applicable
+- Use `Console.Error` for parser warnings/errors
+
+## Current Development Focus
+- Expanding SPARQL query support (see `story/sparql-tests` branch)
+- Aggregate functions recently added
+- Parser compliance with W3C specifications
+
+## Getting Help
+- See CONTRIBUTING.md for contribution guidelines
+- See BUILDING.md for build/test setup details
+- See ARCHITECTURE.md for system design overview
+- Check W3C specs: https://www.w3.org/TR/ (Turtle, SPARQL, OWL2)

--- a/grammars/manchester/Concept.g4
+++ b/grammars/manchester/Concept.g4
@@ -24,18 +24,26 @@ conjunction_restriction: concept_restriction #ConjunctionRestriction
 concept_restriction:
     objectPropertyExpression SOME primary #ExistentialConceptRestriction
     | objectPropertyExpression ONLY primary #UniversalConceptRestriction
+    | objectPropertyExpression VALUE rdfiri #ValueConceptRestriction
     | objectPropertyExpression EXACTLY INTEGERLITERAL primary? #CardinalityConceptRestriction
+    | objectPropertyExpression MIN INTEGERLITERAL primary? #MinCardinalityConceptRestriction
+    | objectPropertyExpression MAX INTEGERLITERAL primary? #MaxCardinalityConceptRestriction
     | dataPropertyExpression SOME dataPrimary #ExistentialDataRestriction
     | dataPropertyExpression ONLY dataPrimary #UniversalDataRestriction
-    | dataPropertyExpression EXACTLY INTEGERLITERAL dataPrimary? #CardinalityConceptRestriction
+    | dataPropertyExpression EXACTLY INTEGERLITERAL dataPrimary? #CardinalityDataRestriction
+    | dataPropertyExpression MIN INTEGERLITERAL dataPrimary? #MinCardinalityDataRestriction
+    | dataPropertyExpression MAX INTEGERLITERAL dataPrimary? #MaxCardinalityDataRestriction
     ;
 
 primary:
     NOT primary                   #NegatedPrimaryConcept
     | concept_restriction                   #RestrictionPrimaryConcept
     | rdfiri                        #IriPrimaryConcept
+    | '{' individual (COMMA individual)* '}' #NominalPrimaryConcept
     | '(' description ')'     #ParenthesizedPrimaryConcept
     ;
+
+individual: rdfiri ;
 
 objectPropertyExpression: rdfiri #ObjectPropertyIri
     | INVERSE rdfiri #InverseObjectProperty

--- a/grammars/manchester/ManchesterCommonTokens.g4
+++ b/grammars/manchester/ManchesterCommonTokens.g4
@@ -50,4 +50,5 @@ ONLY: 'only';
 EXACTLY: 'exactly';
 MIN: 'min';
 MAX: 'max';
+VALUE: 'value';
 SELF: 'Self';

--- a/grammars/sparql/Sparql.g4
+++ b/grammars/sparql/Sparql.g4
@@ -141,12 +141,55 @@ numericExpression :    additiveExpression;
 additiveExpression:    multiplicativeExpression ( '+' multiplicativeExpression | '-' multiplicativeExpression | ( numericLiteral ) ( ( '*' unaryExpression ) | ( '/' unaryExpression ) )* )*;
 multiplicativeExpression: unaryExpression ( '*' unaryExpression | '/' unaryExpression )*;
 unaryExpression   :    '!' primaryExpression | '+' primaryExpression | '-' primaryExpression | primaryExpression;
-primaryExpression :    brackettedExpression | builtInCall | iriOrFunction | rdfLiteral | numericLiteral | booleanLiteral | var | exprTripleTerm;
+
+primaryExpression :    brackettedExpression #BracketedPrimaryExpression
+| builtInCall #BuiltInCallPrimaryExpression 
+| iriOrFunction #IriOrFunctionPrimaryExpression 
+| rdfLiteral #RdfLiteralPrimaryExpression 
+| numericLiteral #NumericLiteralPrimaryExpression 
+| booleanLiteral #BooleanLiteralPrimaryExpression
+| var #VariablePrimaryExpression
+| exprTripleTerm #ExprTripleTermPrimaryExpression
+;
 exprTripleTerm    :    '<<(' exprTripleTermSubject verb exprTripleTermObject ')>>';
 exprTripleTermSubject: iri | rdfLiteral | numericLiteral | booleanLiteral | var;
 exprTripleTermObject: iri | rdfLiteral | numericLiteral | booleanLiteral | var | exprTripleTerm;
 brackettedExpression: '(' expression ')';
-builtInCall       :    aggregate | 'STR' '(' expression ')' | 'LANG' '(' expression ')' | 'LANGMATCHES' '(' expression ',' expression ')' | 'LANGDIR' '(' expression ')' | 'DATATYPE' '(' expression ')' | 'BOUND' '(' var ')' | 'IRI' '(' expression ')' | 'URI' '(' expression ')' | 'BNODE' ( '(' expression ')' | NIL ) | 'RAND' NIL | 'ABS' '(' expression ')' | 'CEIL' '(' expression ')' | 'FLOOR' '(' expression ')' | 'ROUND' '(' expression ')' | 'CONCAT' expressionList | substringExpression | 'STRLEN' '(' expression ')' | strReplaceExpression | 'UCASE' '(' expression ')' | 'LCASE' '(' expression ')' | 'ENCODE_FOR_URI' '(' expression ')' | 'CONTAINS' '(' expression ',' expression ')' | 'STRSTARTS' '(' expression ',' expression ')' | 'STRENDS' '(' expression ',' expression ')' | 'STRBEFORE' '(' expression ',' expression ')' | 'STRAFTER' '(' expression ',' expression ')' | 'YEAR' '(' expression ')' | 'MONTH' '(' expression ')' | 'DAY' '(' expression ')' | 'HOURS' '(' expression ')' | 'MINUTES' '(' expression ')' | 'SECONDS' '(' expression ')' | 'TIMEZONE' '(' expression ')' | 'TZ' '(' expression ')' | 'NOW' NIL | 'UUID' NIL | 'STRUUID' NIL | 'MD5' '(' expression ')' | 'SHA1' '(' expression ')' | 'SHA256' '(' expression ')' | 'SHA384' '(' expression ')' | 'SHA512' '(' expression ')' | 'COALESCE' expressionList | 'IF' '(' expression ',' expression ',' expression ')' | 'STRLANG' '(' expression ',' expression ')' | 'STRLANGDIR' '(' expression ',' expression ',' expression ')' | 'STRDT' '(' expression ',' expression ')' | 'sameTerm' '(' expression ',' expression ')' | 'isIRI' '(' expression ')' | 'isURI' '(' expression ')' | 'isBLANK' '(' expression ')' | 'isLITERAL' '(' expression ')' | 'isNUMERIC' '(' expression ')' | 'hasLANG' '(' expression ')' | 'hasLANGDIR' '(' expression ')' | regexExpression | existsFunc | notExistsFunc | 'isTRIPLE' '(' expression ')' | 'TRIPLE' '(' expression ',' expression ',' expression ')' | 'SUBJECT' '(' expression ')' | 'PREDICATE' '(' expression ')' | 'OBJECT' '(' expression ')';
+builtInCall       :    aggregate 
+| 'STR' '(' expression ')' 
+| 'LANG' '(' expression ')' 
+| 'LANGMATCHES' '(' expression ',' expression ')' 
+| 'LANGDIR' '(' expression ')' 
+| 'DATATYPE' '(' expression ')' 
+| 'BOUND' '(' var ')' 
+| 'IRI' '(' expression ')' 
+| 'URI' '(' expression ')' 
+| 'BNODE' ( '(' expression ')' | NIL ) 
+| 'RAND' NIL 
+| 'ABS' '(' expression ')' 
+| 'CEIL' '(' expression ')' 
+| 'FLOOR' '(' expression ')' 
+| 'ROUND' '(' expression ')' 
+| 'CONCAT' expressionList 
+| substringExpression 
+| 'STRLEN' '(' expression ')' 
+| strReplaceExpression 
+| 'UCASE' '(' expression ')' 
+| 'LCASE' '(' expression ')' 
+| 'ENCODE_FOR_URI' '(' expression ')' 
+| 'CONTAINS' '(' expression ',' expression ')' 
+| 'STRSTARTS' '(' expression ',' expression ')' 
+| 'STRENDS' '(' expression ',' expression ')' 
+| 'STRBEFORE' '(' expression ',' expression ')' 
+| 'STRAFTER' '(' expression ',' expression ')' 
+| 'YEAR' '(' expression ')' 
+| 'MONTH' '(' expression ')' 
+| 'DAY' '(' expression ')' 
+| 'HOURS' '(' expression ')' 
+| 'MINUTES' '(' expression ')' 
+| 'SECONDS' '(' expression ')' 
+| 'TIMEZONE' '(' expression ')' 
+| 'TZ' '(' expression ')' | 'NOW' NIL | 'UUID' NIL | 'STRUUID' NIL | 'MD5' '(' expression ')' | 'SHA1' '(' expression ')' | 'SHA256' '(' expression ')' | 'SHA384' '(' expression ')' | 'SHA512' '(' expression ')' | 'COALESCE' expressionList | 'IF' '(' expression ',' expression ',' expression ')' | 'STRLANG' '(' expression ',' expression ')' | 'STRLANGDIR' '(' expression ',' expression ',' expression ')' | 'STRDT' '(' expression ',' expression ')' | 'sameTerm' '(' expression ',' expression ')' | 'isIRI' '(' expression ')' | 'isURI' '(' expression ')' | 'isBLANK' '(' expression ')' | 'isLITERAL' '(' expression ')' | 'isNUMERIC' '(' expression ')' | 'hasLANG' '(' expression ')' | 'hasLANGDIR' '(' expression ')' | regexExpression | existsFunc | notExistsFunc | 'isTRIPLE' '(' expression ')' | 'TRIPLE' '(' expression ',' expression ',' expression ')' | 'SUBJECT' '(' expression ')' | 'PREDICATE' '(' expression ')' | 'OBJECT' '(' expression ')';
 regexExpression   :    'REGEX' '(' expression ',' expression ( ',' expression )? ')';
 substringExpression: 'SUBSTR' '(' expression ',' expression ( ',' expression )? ')';
 strReplaceExpression: 'REPLACE' '(' expression ',' expression ',' expression ( ',' expression )? ')';

--- a/grammars/sparql/Sparql.g4
+++ b/grammars/sparql/Sparql.g4
@@ -189,11 +189,23 @@ builtInCall       :    aggregate
 | 'MINUTES' '(' expression ')' 
 | 'SECONDS' '(' expression ')' 
 | 'TIMEZONE' '(' expression ')' 
-| 'TZ' '(' expression ')' | 'NOW' NIL | 'UUID' NIL | 'STRUUID' NIL | 'MD5' '(' expression ')' | 'SHA1' '(' expression ')' | 'SHA256' '(' expression ')' | 'SHA384' '(' expression ')' | 'SHA512' '(' expression ')' | 'COALESCE' expressionList | 'IF' '(' expression ',' expression ',' expression ')' | 'STRLANG' '(' expression ',' expression ')' | 'STRLANGDIR' '(' expression ',' expression ',' expression ')' | 'STRDT' '(' expression ',' expression ')' | 'sameTerm' '(' expression ',' expression ')' | 'isIRI' '(' expression ')' | 'isURI' '(' expression ')' | 'isBLANK' '(' expression ')' | 'isLITERAL' '(' expression ')' | 'isNUMERIC' '(' expression ')' | 'hasLANG' '(' expression ')' | 'hasLANGDIR' '(' expression ')' | regexExpression | existsFunc | notExistsFunc | 'isTRIPLE' '(' expression ')' | 'TRIPLE' '(' expression ',' expression ',' expression ')' | 'SUBJECT' '(' expression ')' | 'PREDICATE' '(' expression ')' | 'OBJECT' '(' expression ')';
+| 'TZ' '(' expression ')' 
+| 'NOW' NIL 
+| 'UUID' NIL 
+| 'STRUUID' NIL 
+| 'MD5' '(' expression ')' 
+| 'SHA1' '(' expression ')' | 'SHA256' '(' expression ')' | 'SHA384' '(' expression ')' | 'SHA512' '(' expression ')' | 'COALESCE' expressionList | 'IF' '(' expression ',' expression ',' expression ')' | 'STRLANG' '(' expression ',' expression ')' | 'STRLANGDIR' '(' expression ',' expression ',' expression ')' | 'STRDT' '(' expression ',' expression ')' | 'sameTerm' '(' expression ',' expression ')' | 'isIRI' '(' expression ')' | 'isURI' '(' expression ')' | 'isBLANK' '(' expression ')' | 'isLITERAL' '(' expression ')' | 'isNUMERIC' '(' expression ')' | 'hasLANG' '(' expression ')' | 'hasLANGDIR' '(' expression ')' | regexExpression | existsFunc | notExistsFunc | 'isTRIPLE' '(' expression ')' | 'TRIPLE' '(' expression ',' expression ',' expression ')' | 'SUBJECT' '(' expression ')' | 'PREDICATE' '(' expression ')' | 'OBJECT' '(' expression ')';
 regexExpression   :    'REGEX' '(' expression ',' expression ( ',' expression )? ')';
 substringExpression: 'SUBSTR' '(' expression ',' expression ( ',' expression )? ')';
 strReplaceExpression: 'REPLACE' '(' expression ',' expression ',' expression ( ',' expression )? ')';
 existsFunc        :    'EXISTS' groupGraphPattern;
 notExistsFunc     :    'NOT' 'EXISTS' groupGraphPattern;
-aggregate         :    'COUNT' '(' 'DISTINCT'? ( '*' | expression ) ')' | 'SUM' '(' 'DISTINCT'? expression ')' | 'MIN' '(' 'DISTINCT'? expression ')' | 'MAX' '(' 'DISTINCT'? expression ')' | 'AVG' '(' 'DISTINCT'? expression ')' | 'SAMPLE' '(' 'DISTINCT'? expression ')' | 'GROUP_CONCAT' '(' 'DISTINCT'? expression ( ';' 'SEPARATOR' '=' stringLiteral )? ')';
+aggregate         :    'COUNT' '(' 'DISTINCT'? ( '*' | expression ) ')' #CountAggregate
+    | 'SUM' '(' 'DISTINCT'? expression ')' #SumAggregate
+    | 'MIN' '(' 'DISTINCT'? expression ')' #MinAggregate
+    | 'MAX' '(' 'DISTINCT'? expression ')' #MaxAggregate
+    | 'AVG' '(' 'DISTINCT'? expression ')' #AvgAggregate
+    | 'SAMPLE' '(' 'DISTINCT'? expression ')' #SampleAggregate
+    | 'GROUP_CONCAT' '(' 'DISTINCT'? expression ( ';' 'SEPARATOR' '=' stringLiteral )? ')' #GroupConcatAggregate
+    ;
 iriOrFunction     :    iri argList?;

--- a/src/Rdf/Datastore.fs
+++ b/src/Rdf/Datastore.fs
@@ -132,39 +132,39 @@ type Datastore(reifiedTriples: QuadTable,
         let p = pat.Predicate
         let o = pat.Object
         match g, s, p, o with
-        | Resource gRes, Resource sRes, Resource pRes, Resource oRes ->
+        | Term.Resource gRes, Term.Resource sRes, Term.Resource pRes, Term.Resource oRes ->
             let q = { Quad.tripleId = gRes; subject =  sRes; predicate = pRes; obj = oRes }
             if this.NamedGraphs.Contains q then
                 seq { yield q }
             else
                 Seq.empty
-        | Resource gRes,  Resource sRes, Resource pRes, Variable _ ->
+        | Term.Resource gRes,  Term.Resource sRes, Term.Resource pRes, Term.Variable _ ->
             this.NamedGraphs.GetQuadsWithIdSubjectPredicate (gRes, sRes, pRes)
-        | Resource gRes, Resource sRes, Variable _, Resource oRes ->
+        | Term.Resource gRes, Term.Resource sRes, Term.Variable _, Term.Resource oRes ->
             this.NamedGraphs.GetQuadsWithIdSubjectObject (gRes, sRes, oRes)
-        | Resource gRes, Variable _, Resource pRes, Resource oRes ->
+        | Term.Resource gRes, Term.Variable _, Term.Resource pRes, Term.Resource oRes ->
             this.NamedGraphs.GetQuadsWithIdObjectPredicate (gRes, oRes, pRes)
-        | Resource gRes,  Resource sRes, Variable _, Variable _ ->
+        | Term.Resource gRes,  Term.Resource sRes, Term.Variable _, Term.Variable _ ->
             this.NamedGraphs.GetQuadsWithIdSubject (gRes, sRes)
-        | Resource gRes, Variable _, Resource pRes, Variable _ ->
+        | Term.Resource gRes, Term.Variable _, Term.Resource pRes, Term.Variable _ ->
             this.NamedGraphs.GetQuadsWithIdPredicate (gRes, pRes)
-        | Resource gRes, Variable _, Variable _, Resource oRes ->
+        | Term.Resource gRes, Term.Variable _, Term.Variable _, Term.Resource oRes ->
             this.NamedGraphs.GetQuadsWithIdObject (gRes, oRes)
-        | Resource gRes, Variable _, Variable _, Variable _ ->
+        | Term.Resource gRes, Term.Variable _, Term.Variable _, Term.Variable _ ->
             this.NamedGraphs.GetQuadsWithId (gRes)
-        | Variable _,  Resource sRes, Resource pRes, Variable _ ->
+        | Term.Variable _,  Term.Resource sRes, Term.Resource pRes, Term.Variable _ ->
             this.NamedGraphs.GetQuadsWithSubjectPredicate (sRes, pRes)
-        | Variable _, Resource sRes, Variable _, Resource oRes ->
+        | Term.Variable _, Term.Resource sRes, Term.Variable _, Term.Resource oRes ->
             this.NamedGraphs.GetQuadsWithSubjectObject (sRes, oRes)
-        | Variable _, Variable _, Resource pRes, Resource oRes ->
+        | Term.Variable _, Term.Variable _, Term.Resource pRes, Term.Resource oRes ->
             this.NamedGraphs.GetQuadsWithObjectPredicate (oRes, pRes)
-        | Variable _,  Resource sRes, Variable _, Variable _ ->
+        | Term.Variable _,  Term.Resource sRes, Term.Variable _, Term.Variable _ ->
             this.NamedGraphs.GetQuadsWithSubject (sRes)
-        | Variable _, Variable _, Resource pRes, Variable _ ->
+        | Term.Variable _, Term.Variable _, Term.Resource pRes, Term.Variable _ ->
             this.NamedGraphs.GetQuadsWithPredicate (pRes)
-        | Variable _, Variable _, Variable _, Resource oRes ->
+        | Term.Variable _, Term.Variable _, Term.Variable _, Term.Resource oRes ->
             this.NamedGraphs.GetQuadsWithObject (oRes)
-        | Variable _, Variable _, Variable _, Variable _ ->
+        | Term.Variable _, Term.Variable _, Term.Variable _, Term.Variable _ ->
             this.NamedGraphs.GetQuads
-        | Variable s, Resource i, Resource i1, Resource i2 ->
+        | Term.Variable s, Term.Resource i, Term.Resource i1, Term.Resource i2 ->
             this.NamedGraphs.GetQuadsWithTriple (i, i1, i2)

--- a/src/Rdf/Query.fs
+++ b/src/Rdf/Query.fs
@@ -71,17 +71,9 @@ module Query =
          Object = Object}
         
 
-    type GroupGraphPattern =
-            QueryComponent list
-    and QueryComponent =
-        | Pattern of QuadPattern
-        | Group of GroupGraphPattern
-        | Optional of OptionalPattern
-    and OptionalPattern = Optional of GroupGraphPattern
-    
     [<StructuralComparison>]
     [<StructuralEquality>]
-    type Aggregate = 
+    type Aggregate =
         | Count of distinct: bool * term: Term option (* None for * *)
         | Sum of distinct: bool * term: Term
         | Min of distinct: bool * term: Term
@@ -96,7 +88,9 @@ module Query =
         | ExprVariable of string
         | ExprAggregate of Aggregate
         | ExprTerm of Term
-        (* Add more as needed, e.g., Function call, literals, etc. *)
+        | ExprBinaryOp of op: string * left: Expression * right: Expression
+        | ExprUnaryOp of op: string * operand: Expression
+        | ExprBuiltInCall of name: string * args: Expression list
 
     [<StructuralComparison>]
     [<StructuralEquality>]
@@ -104,11 +98,22 @@ module Query =
         | ProjectVariable of string
         | ProjectExpression of Expression * alias: string
 
-    [<StructuralComparison>]
-    [<StructuralEquality>]
+    type GroupGraphPattern =
+            QueryComponent list
+    and QueryComponent =
+        | Pattern of QuadPattern
+        | Group of GroupGraphPattern
+        | Optional of OptionalPattern
+        | Filter of Expression
+        | Union of GroupGraphPattern list
+        | Minus of GroupGraphPattern
+        | Values of vars: string list * rows: Term list list
+        | Bind of expr: Expression * varName: string
+        | Subquery of SelectQuery
+    and OptionalPattern = Optional of GroupGraphPattern
     (* The projection is the list of variable names used in the select clause, without the question mark.
        The Basic Graph Pattern is a list of Triple Patterns *)
-    type SelectQuery =
+    and SelectQuery =
         {Projection: ProjectionElement list; Query: GroupGraphPattern; GroupBy: Expression list }
     
      

--- a/src/Rdf/Query.fs
+++ b/src/Rdf/Query.fs
@@ -95,6 +95,7 @@ module Query =
     type Expression =
         | ExprVariable of string
         | ExprAggregate of Aggregate
+        | ExprTerm of Term
         (* Add more as needed, e.g., Function call, literals, etc. *)
 
     [<StructuralComparison>]

--- a/src/Rdf/Query.fs
+++ b/src/Rdf/Query.fs
@@ -81,9 +81,33 @@ module Query =
     
     [<StructuralComparison>]
     [<StructuralEquality>]
+    type Aggregate = 
+        | Count of distinct: bool * term: Term option (* None for * *)
+        | Sum of distinct: bool * term: Term
+        | Min of distinct: bool * term: Term
+        | Max of distinct: bool * term: Term
+        | Avg of distinct: bool * term: Term
+        | Sample of distinct: bool * term: Term
+        | GroupConcat of distinct: bool * term: Term * separator: string option
+
+    [<StructuralComparison>]
+    [<StructuralEquality>]
+    type Expression =
+        | ExprVariable of string
+        | ExprAggregate of Aggregate
+        (* Add more as needed, e.g., Function call, literals, etc. *)
+
+    [<StructuralComparison>]
+    [<StructuralEquality>]
+    type ProjectionElement =
+        | ProjectVariable of string
+        | ProjectExpression of Expression * alias: string
+
+    [<StructuralComparison>]
+    [<StructuralEquality>]
     (* The projection is the list of variable names used in the select clause, without the question mark.
        The Basic Graph Pattern is a list of Triple Patterns *)
     type SelectQuery =
-        {Projection: string list; Query: GroupGraphPattern }
+        {Projection: ProjectionElement list; Query: GroupGraphPattern; GroupBy: Expression list }
     
      

--- a/src/Rdf/QueryProcessor.fs
+++ b/src/Rdf/QueryProcessor.fs
@@ -10,21 +10,164 @@ namespace DagSemTools.Rdf
 
 open System.Numerics
 open Microsoft.FSharp.Collections
+open DagSemTools.Ingress
 open DagSemTools.Rdf.Ingress
 open DagSemTools.Rdf.Query
 
 module QueryProcessor =
     
+    let resolveTerm (binding: Map<string, GraphElementId>) (term: Term) : Term =
+        match term with
+        | Term.Variable v -> 
+            match binding.TryFind v with
+            | Some id -> Term.Resource id
+            | None -> term
+        | _ -> term
+
+    let rec isTrue (gel: GraphElement) : bool =
+        match Ingress.tryGetBoolLiteral gel with
+        | Some b -> b
+        | None ->
+            match Ingress.tryGetNonNegativeIntegerLiteral gel with
+            | Some i -> i <> BigInteger.Zero
+            | None -> false
+
+    let rec evalExpr (datastore : Datastore) (binding: Map<string, GraphElementId>) (expr: Expression) : GraphElementId option =
+        if box expr = null then None else
+        match expr with
+        | ExprVariable v -> binding.TryFind v
+        | ExprAggregate _ -> None // Aggregates handled after grouping
+        | ExprTerm (Term.Resource id) -> Some id
+        | ExprTerm (Term.Variable v) -> binding.TryFind v
+        | ExprUnaryOp (op, operand) ->
+            evalExpr datastore binding operand
+            |> Option.bind (fun operandId ->
+                let operandGel = datastore.Resources.GetGraphElement operandId
+                match op with
+                | "!" ->
+                    let b = isTrue operandGel
+                    Some (datastore.Resources.AddLiteralResource (BooleanLiteral (not b)))
+                | "+" -> Some operandId // Assuming numeric, for now just return
+                | "-" ->
+                    match Ingress.tryGetNonNegativeIntegerLiteral operandGel with
+                    | Some i -> Some (datastore.Resources.AddLiteralResource (IntegerLiteral (-i)))
+                    | None -> None
+                | _ -> None)
+        | ExprBinaryOp (op, left, right) ->
+            match op with
+            | "||" ->
+                let leftTrue = evalExpr datastore binding left |> Option.map (datastore.Resources.GetGraphElement >> isTrue) |> Option.defaultValue false
+                if leftTrue then 
+                    Some (datastore.Resources.AddLiteralResource (BooleanLiteral true))
+                else
+                    let rightTrue = evalExpr datastore binding right |> Option.map (datastore.Resources.GetGraphElement >> isTrue) |> Option.defaultValue false
+                    Some (datastore.Resources.AddLiteralResource (BooleanLiteral rightTrue))
+            | "&&" ->
+                let leftTrue = evalExpr datastore binding left |> Option.map (datastore.Resources.GetGraphElement >> isTrue) |> Option.defaultValue false
+                if not leftTrue then 
+                    Some (datastore.Resources.AddLiteralResource (BooleanLiteral false))
+                else
+                    let rightTrue = evalExpr datastore binding right |> Option.map (datastore.Resources.GetGraphElement >> isTrue) |> Option.defaultValue false
+                    Some (datastore.Resources.AddLiteralResource (BooleanLiteral rightTrue))
+            | "=" | "!=" | "<" | ">" | "<=" | ">=" ->
+                match evalExpr datastore binding left, evalExpr datastore binding right with
+                | Some lId, Some rId ->
+                    let lGel = datastore.Resources.GetGraphElement lId
+                    let rGel = datastore.Resources.GetGraphElement rId
+                    
+                    let tryGetAnyNumeric (gel: GraphElement) =
+                        match gel with
+                        | GraphLiteral (IntegerLiteral i) -> Some (decimal i)
+                        | GraphLiteral (DecimalLiteral d) -> Some d
+                        | GraphLiteral (DoubleLiteral d) -> Some (decimal d)
+                        | GraphLiteral (TypedLiteral (tp, v)) when List.contains (tp.ToString()) [Namespaces.XsdInt; Namespaces.XsdInteger; Namespaces.XsdNonNegativeInteger; Namespaces.XsdDecimal] ->
+                            match System.Decimal.TryParse(v) with
+                            | true, i -> Some i
+                            | _ -> None
+                        | _ -> None
+
+                    let cmpResult = 
+                        match tryGetAnyNumeric lGel, tryGetAnyNumeric rGel with
+                        | Some lNum, Some rNum -> Some (lNum.CompareTo(rNum))
+                        | _ -> 
+                            match lGel, rGel with
+                            | GraphLiteral(LiteralString l), GraphLiteral(LiteralString r) -> Some (l.CompareTo(r))
+                            | _ -> Some (compare lGel rGel)
+                    
+                    match cmpResult with
+                    | Some cmp ->
+                        let res = 
+                            match op with
+                            | "=" -> cmp = 0
+                            | "!=" -> cmp <> 0
+                            | "<" -> cmp < 0
+                            | ">" -> cmp > 0
+                            | "<=" -> cmp <= 0
+                            | ">=" -> cmp >= 0
+                            | _ -> false
+                        Some (datastore.Resources.AddLiteralResource (BooleanLiteral res))
+                    | None -> None
+                | _ -> None
+            | _ -> None
+        | ExprBuiltInCall (name, args) ->
+            match name.ToUpperInvariant() with
+            | "BOUND" ->
+                match args with
+                | [ExprVariable v] ->
+                    Some (datastore.Resources.AddLiteralResource (BooleanLiteral (binding.ContainsKey v)))
+                | _ -> None
+            | "STR" ->
+                match args with
+                | [arg] ->
+                    evalExpr datastore binding arg 
+                    |> Option.map (fun id -> 
+                        let gel = datastore.Resources.GetGraphElement id
+                        datastore.Resources.AddLiteralResource (LiteralString (gel.ToString())))
+                | _ -> None
+            | _ -> None
+
     let rec GetBindingsForGraphGroup
         (datastore : Datastore)
         (patterns: QueryComponent list)
         (currentBindings: Map<string, GraphElementId> list)
         : Map<string, GraphElementId> list =
+
         match patterns with
         | [] -> currentBindings
         | pattern :: rest ->
             match pattern with
-            | Group groupPattern -> GetBindingsForGraphGroup datastore groupPattern currentBindings
+            | Group groupPattern -> 
+                let groupBindings = GetBindingsForGraphGroup datastore groupPattern currentBindings
+                GetBindingsForGraphGroup datastore rest groupBindings
+            | Pattern q ->
+                let (newBindings : Map<string, GraphElementId> list) =
+                    currentBindings
+                    |> List.collect (fun binding ->
+                        let resolvedPat = { 
+                            Graph = resolveTerm binding q.Graph;
+                            Subject = resolveTerm binding q.Subject;
+                            Predicate = resolveTerm binding q.Predicate;
+                            Object = resolveTerm binding q.Object 
+                        }
+                        let results = datastore.GetQuads(resolvedPat)
+                        results
+                        |> Seq.collect (fun quad ->
+                            let mutable newBinding = binding
+                            let mutable compatible = true
+                            
+                            let checkAndAdd v id (b: Map<string, uint32>) =
+                                match b.TryFind v with
+                                | Some existing when existing <> id -> compatible <- false; b
+                                | _ -> Map.add v id b
+
+                            match q.Subject with | Term.Variable v -> newBinding <- checkAndAdd v quad.subject newBinding | _ -> ()
+                            match q.Predicate with | Term.Variable v -> newBinding <- checkAndAdd v quad.predicate newBinding | _ -> ()
+                            match q.Object with | Term.Variable v -> newBinding <- checkAndAdd v quad.obj newBinding | _ -> ()
+                            match q.Graph with | Term.Variable v -> newBinding <- checkAndAdd v quad.tripleId newBinding | _ -> ()
+                            
+                            if compatible then [newBinding] else [])
+                        |> Seq.toList)
+                GetBindingsForGraphGroup datastore rest newBindings
             | Query.QueryComponent.Optional (Query.OptionalPattern.Optional optionalGroup) ->
                 let (newBindings : Map<string, GraphElementId> list) =
                     currentBindings
@@ -35,9 +178,14 @@ module QueryProcessor =
                         else
                             optionalMatches)
                 GetBindingsForGraphGroup datastore rest newBindings
-            | Query.QueryComponent.Filter _expr ->
-                // TODO: implement FILTER evaluation
-                GetBindingsForGraphGroup datastore rest currentBindings
+            | Query.QueryComponent.Filter expr ->
+                let filtered =
+                    currentBindings
+                    |> List.filter (fun binding ->
+                        match evalExpr datastore binding expr with
+                        | Some id -> isTrue (datastore.Resources.GetGraphElement id)
+                        | None -> false)
+                GetBindingsForGraphGroup datastore rest filtered
             | Query.QueryComponent.Union groups ->
                 let unionResults =
                     groups
@@ -78,8 +226,13 @@ module QueryProcessor =
                             else None))
                 GetBindingsForGraphGroup datastore rest newBindings
             | Query.QueryComponent.Bind (expr, varName) ->
-                // TODO: implement expression evaluation; for now skip
-                GetBindingsForGraphGroup datastore rest currentBindings
+                let newBindings =
+                    currentBindings
+                    |> List.choose (fun binding ->
+                        match evalExpr datastore binding expr with
+                        | Some id -> Some (Map.add varName id binding)
+                        | None -> None)
+                GetBindingsForGraphGroup datastore rest newBindings
             | Query.QueryComponent.Subquery subSelect ->
                 let subResults = Answer datastore subSelect
                 let newBindings =
@@ -142,16 +295,6 @@ module QueryProcessor =
     and public Answer (datastore : Datastore) (query : Query.SelectQuery) : Map<string, GraphElementId> list =
         let results = GetBindingsForGraphGroup datastore query.Query [Map.empty]
         
-        let evalExpr (binding: Map<string, GraphElementId>) (expr: Expression) : GraphElementId option =
-            match expr with
-            | ExprVariable v -> binding.TryFind v
-            | ExprAggregate _ -> None // Aggregates handled after grouping
-            | ExprTerm (Term.Resource id) -> Some id
-            | ExprTerm (Term.Variable v) -> binding.TryFind v
-            | ExprBinaryOp _ -> None // TODO: implement
-            | ExprUnaryOp _ -> None  // TODO: implement
-            | ExprBuiltInCall _ -> None // TODO: implement
-
         let resultsAfterGrouping =
             if query.GroupBy.IsEmpty then
                 let hasAggregates = 
@@ -166,7 +309,7 @@ module QueryProcessor =
                 results
                 |> List.groupBy (fun binding ->
                     query.GroupBy 
-                    |> List.map (fun expr -> evalExpr binding expr)
+                    |> List.map (fun expr -> evalExpr datastore binding expr)
                 )
                 |> List.map snd
 
@@ -263,7 +406,7 @@ module QueryProcessor =
                         | Some value -> Map.add alias value acc
                         | None -> acc
                     | _ ->
-                        match evalExpr firstBinding expr with
+                        match evalExpr datastore firstBinding expr with
                         | Some value -> Map.add alias value acc
                         | None -> acc
             ) Map.empty

--- a/src/Rdf/QueryProcessor.fs
+++ b/src/Rdf/QueryProcessor.fs
@@ -8,6 +8,7 @@
 
 namespace DagSemTools.Rdf
 
+open System.Numerics
 open Microsoft.FSharp.Collections
 open DagSemTools.Rdf.Ingress
 open DagSemTools.Rdf.Query
@@ -76,22 +77,128 @@ module QueryProcessor =
                 GetBindingsForGraphGroup datastore rest newBindings
         
     
-    let RemoveNonProjectedBindings (projectedVars: ProjectionElement list) (binding: Map<string, GraphElementId>) : Map<string, GraphElementId> =
-            projectedVars
+    let public Answer (datastore : Datastore) (query : Query.SelectQuery) : Map<string, GraphElementId> list =
+        let results = GetBindingsForGraphGroup datastore query.Query [Map.empty]
+        
+        let evalExpr (binding: Map<string, GraphElementId>) (expr: Expression) : GraphElementId option =
+            match expr with
+            | ExprVariable v -> binding.TryFind v
+            | ExprAggregate _ -> None // Aggregates handled after grouping
+
+        let resultsAfterGrouping =
+            if query.GroupBy.IsEmpty then
+                let hasAggregates = 
+                    query.Projection 
+                    |> List.exists (function ProjectionElement.ProjectExpression(ExprAggregate _, _) -> true | _ -> false)
+                if hasAggregates then
+                    if results.IsEmpty then [[]] // One empty group for aggregates over empty set
+                    else [results]
+                else
+                    results |> List.map (fun r -> [r])
+            else
+                results
+                |> List.groupBy (fun binding ->
+                    query.GroupBy 
+                    |> List.map (fun expr -> evalExpr binding expr)
+                )
+                |> List.map snd
+
+        let evalAggregate (group: Map<string, GraphElementId> list) (agg: Aggregate) : GraphElementId option =
+            match agg with
+            | Sum(distinct, Term.Variable v) ->
+                let values = 
+                    let allValues = 
+                        group 
+                        |> List.choose (fun b -> b.TryFind v)
+                    if distinct then
+                        allValues |> List.distinct
+                    else
+                        allValues
+                    |> List.choose (fun id -> 
+                        let gel = datastore.Resources.GetGraphElement id
+                        DagSemTools.Rdf.Ingress.tryGetNonNegativeIntegerLiteral gel)
+                if values.IsEmpty then 
+                    Some (datastore.Resources.AddLiteralResource (DagSemTools.Ingress.RdfLiteral.IntegerLiteral (BigInteger 0)))
+                else
+                    let sum = values |> List.reduce (+)
+                    Some (datastore.Resources.AddLiteralResource (DagSemTools.Ingress.RdfLiteral.IntegerLiteral sum))
+            | Count(distinct, termOpt) ->
+                let count = 
+                    match termOpt with
+                    | None -> // COUNT(*)
+                        group.Length
+                    | Some (Term.Variable v) ->
+                        let values = 
+                            group 
+                            |> List.choose (fun b -> b.TryFind v)
+                        if distinct then
+                            (values |> List.distinct).Length
+                        else
+                            values.Length
+                    | Some (Term.Resource r) ->
+                        if distinct then 1 else group.Length
+                Some (datastore.Resources.AddLiteralResource (DagSemTools.Ingress.RdfLiteral.IntegerLiteral (BigInteger count)))
+            | Min(distinct, Term.Variable v) ->
+                let values = 
+                    group 
+                    |> List.choose (fun b -> b.TryFind v)
+                    |> List.choose (fun id -> 
+                        let gel = datastore.Resources.GetGraphElement id
+                        DagSemTools.Rdf.Ingress.tryGetNonNegativeIntegerLiteral gel)
+                if values.IsEmpty then None
+                else
+                    let min = values |> List.min
+                    Some (datastore.Resources.AddLiteralResource (DagSemTools.Ingress.RdfLiteral.IntegerLiteral min))
+            | Max(distinct, Term.Variable v) ->
+                let values = 
+                    group 
+                    |> List.choose (fun b -> b.TryFind v)
+                    |> List.choose (fun id -> 
+                        let gel = datastore.Resources.GetGraphElement id
+                        DagSemTools.Rdf.Ingress.tryGetNonNegativeIntegerLiteral gel)
+                if values.IsEmpty then None
+                else
+                    let max = values |> List.max
+                    Some (datastore.Resources.AddLiteralResource (DagSemTools.Ingress.RdfLiteral.IntegerLiteral max))
+            | Avg(distinct, Term.Variable v) ->
+                let values = 
+                    let allValues = 
+                        group 
+                        |> List.choose (fun b -> b.TryFind v)
+                    if distinct then
+                        allValues |> List.distinct
+                    else
+                        allValues
+                    |> List.choose (fun id -> 
+                        let gel = datastore.Resources.GetGraphElement id
+                        DagSemTools.Rdf.Ingress.tryGetNonNegativeIntegerLiteral gel)
+                if values.IsEmpty then None
+                else
+                    let sum = values |> List.reduce (+)
+                    let avg = sum / (BigInteger values.Length)
+                    Some (datastore.Resources.AddLiteralResource (DagSemTools.Ingress.RdfLiteral.IntegerLiteral avg))
+            | _ -> None
+
+        resultsAfterGrouping
+        |> List.map (fun group ->
+            let firstBinding = group.Head
+            query.Projection
             |> List.fold (fun acc element ->
                 match element with
                 | ProjectionElement.ProjectVariable var ->
-                    match binding.TryFind var with
+                    match firstBinding.TryFind var with
                     | Some value -> Map.add var value acc
                     | None -> acc
-                | ProjectionElement.ProjectExpression (_, alias) ->
-                    // Aggregates are not yet supported in the Answer processor
-                    match binding.TryFind alias with
-                    | Some value -> Map.add alias value acc
-                    | None -> acc
-                ) Map.empty
-    let public Answer (datastore : Datastore) (query : Query.SelectQuery) : Map<string, GraphElementId> list =
-        let results = GetBindingsForGraphGroup datastore query.Query [Map.empty]
-        results
-        |> List.map (RemoveNonProjectedBindings query.Projection)
+                | ProjectionElement.ProjectExpression (expr, alias) ->
+                    match expr with
+                    | ExprAggregate agg ->
+                        match evalAggregate group agg with
+                        | Some value -> Map.add alias value acc
+                        | None -> acc
+                    | _ ->
+                        match evalExpr firstBinding expr with
+                        | Some value -> Map.add alias value acc
+                        | None -> acc
+            ) Map.empty
+        )
         

--- a/src/Rdf/QueryProcessor.fs
+++ b/src/Rdf/QueryProcessor.fs
@@ -41,34 +41,34 @@ module QueryProcessor =
                         let boundPattern =
                             { Graph = 
                                   match pattern.Graph with
-                                  | Variable vName when binding.ContainsKey vName -> Resource binding.[vName]
+                                  | Term.Variable vName when binding.ContainsKey vName -> Term.Resource binding.[vName]
                                   | _ -> pattern.Graph
                               Subject = 
                                 match pattern.Subject with
-                                | Variable vName when binding.ContainsKey vName -> Resource binding.[vName]
+                                | Term.Variable vName when binding.ContainsKey vName -> Term.Resource binding.[vName]
                                 | _ -> pattern.Subject
                               Predicate = 
                                 match pattern.Predicate with
-                                | Variable vName when binding.ContainsKey vName -> Resource binding.[vName]
+                                | Term.Variable vName when binding.ContainsKey vName -> Term.Resource binding.[vName]
                                 | _ -> pattern.Predicate
                               Object = 
                                 match pattern.Object with
-                                | Variable vName when binding.ContainsKey vName -> Resource binding.[vName]
+                                | Term.Variable vName when binding.ContainsKey vName -> Term.Resource binding.[vName]
                                 | _ -> pattern.Object }
                         datastore.GetQuads(boundPattern)
                         |> Seq.map (fun triple ->
                             let newBindingPairs =
                                 [ match pattern.Graph with
-                                  | Variable vName when not (binding.ContainsKey vName) -> yield (vName, triple.tripleId)
+                                  | Term.Variable vName when not (binding.ContainsKey vName) -> yield (vName, triple.tripleId)
                                   | _ -> ()
                                   match pattern.Subject with
-                                  | Variable vName when not (binding.ContainsKey vName) -> yield (vName, triple.subject)
+                                  | Term.Variable vName when not (binding.ContainsKey vName) -> yield (vName, triple.subject)
                                   | _ -> ()
                                   match pattern.Predicate with
-                                  | Variable vName when not (binding.ContainsKey vName) -> yield (vName, triple.predicate)
+                                  | Term.Variable vName when not (binding.ContainsKey vName) -> yield (vName, triple.predicate)
                                   | _ -> ()
                                   match pattern.Object with
-                                  | Variable vName when not (binding.ContainsKey vName) -> yield (vName, triple.obj)
+                                  | Term.Variable vName when not (binding.ContainsKey vName) -> yield (vName, triple.obj)
                                   | _ -> () ]
                             List.fold (fun acc (k, v) -> Map.add k v acc) binding newBindingPairs)
                         |> Seq.toList)
@@ -76,14 +76,22 @@ module QueryProcessor =
                 GetBindingsForGraphGroup datastore rest newBindings
         
     
-    let RemoveNonProjectedBindings (projectedVars: string list) (binding: Map<string, GraphElementId>) : Map<string, GraphElementId> =
+    let RemoveNonProjectedBindings (projectedVars: ProjectionElement list) (binding: Map<string, GraphElementId>) : Map<string, GraphElementId> =
             projectedVars
-            |> List.fold (fun acc var ->
-                match binding.TryFind var with
-                | Some value -> Map.add var value acc
-                | None -> acc) Map.empty
+            |> List.fold (fun acc element ->
+                match element with
+                | ProjectionElement.ProjectVariable var ->
+                    match binding.TryFind var with
+                    | Some value -> Map.add var value acc
+                    | None -> acc
+                | ProjectionElement.ProjectExpression (_, alias) ->
+                    // Aggregates are not yet supported in the Answer processor
+                    match binding.TryFind alias with
+                    | Some value -> Map.add alias value acc
+                    | None -> acc
+                ) Map.empty
     let public Answer (datastore : Datastore) (query : Query.SelectQuery) : Map<string, GraphElementId> list =
         let results = GetBindingsForGraphGroup datastore query.Query [Map.empty]
         results
-        |> List.map (RemoveNonProjectedBindings (query.Projection |> Seq.toList))
+        |> List.map (RemoveNonProjectedBindings query.Projection)
         

--- a/src/Rdf/QueryProcessor.fs
+++ b/src/Rdf/QueryProcessor.fs
@@ -35,7 +35,69 @@ module QueryProcessor =
                         else
                             optionalMatches)
                 GetBindingsForGraphGroup datastore rest newBindings
-            | Query.QueryComponent.Pattern pattern -> 
+            | Query.QueryComponent.Filter _expr ->
+                // TODO: implement FILTER evaluation
+                GetBindingsForGraphGroup datastore rest currentBindings
+            | Query.QueryComponent.Union groups ->
+                let unionResults =
+                    groups
+                    |> List.collect (fun group -> GetBindingsForGraphGroup datastore group currentBindings)
+                    |> List.distinct
+                GetBindingsForGraphGroup datastore rest unionResults
+            | Query.QueryComponent.Minus minusPattern ->
+                let minusResults = GetBindingsForGraphGroup datastore minusPattern [Map.empty]
+                let filtered =
+                    currentBindings
+                    |> List.filter (fun binding ->
+                        minusResults
+                        |> List.forall (fun minusBinding ->
+                            // Keep if no compatible binding exists in minus set
+                            not (minusBinding |> Map.forall (fun k v -> binding.TryFind k = Some v))))
+                GetBindingsForGraphGroup datastore rest filtered
+            | Query.QueryComponent.Values (vars, rows) ->
+                let newBindings =
+                    currentBindings
+                    |> List.collect (fun binding ->
+                        rows
+                        |> List.choose (fun row ->
+                            let resolvedRow =
+                                List.zip vars (row |> List.ofSeq)
+                                |> List.choose (fun (v, t) ->
+                                    match t with
+                                    | Term.Resource id -> Some (v, id)
+                                    | Term.Variable _ -> None) // UNDEF - skip
+                                |> Map.ofList
+                            let compatible =
+                                resolvedRow
+                                |> Map.forall (fun k v ->
+                                    match binding.TryFind k with
+                                    | Some existing -> existing = v
+                                    | None -> true)
+                            if compatible then
+                                Some (Map.fold (fun acc k v -> Map.add k v acc) binding resolvedRow)
+                            else None))
+                GetBindingsForGraphGroup datastore rest newBindings
+            | Query.QueryComponent.Bind (expr, varName) ->
+                // TODO: implement expression evaluation; for now skip
+                GetBindingsForGraphGroup datastore rest currentBindings
+            | Query.QueryComponent.Subquery subSelect ->
+                let subResults = Answer datastore subSelect
+                let newBindings =
+                    currentBindings
+                    |> List.collect (fun binding ->
+                        subResults
+                        |> List.choose (fun subBinding ->
+                            let compatible =
+                                subBinding
+                                |> Map.forall (fun k v ->
+                                    match binding.TryFind k with
+                                    | Some existing -> existing = v
+                                    | None -> true)
+                            if compatible then
+                                Some (Map.fold (fun acc k v -> Map.add k v acc) binding subBinding)
+                            else None))
+                GetBindingsForGraphGroup datastore rest newBindings
+            | Query.QueryComponent.Pattern pattern ->
                 let newBindings =
                     currentBindings
                     |> List.collect (fun binding ->
@@ -75,15 +137,20 @@ module QueryProcessor =
                         |> Seq.toList)
 
                 GetBindingsForGraphGroup datastore rest newBindings
-        
-    
-    let public Answer (datastore : Datastore) (query : Query.SelectQuery) : Map<string, GraphElementId> list =
+
+
+    and public Answer (datastore : Datastore) (query : Query.SelectQuery) : Map<string, GraphElementId> list =
         let results = GetBindingsForGraphGroup datastore query.Query [Map.empty]
         
         let evalExpr (binding: Map<string, GraphElementId>) (expr: Expression) : GraphElementId option =
             match expr with
             | ExprVariable v -> binding.TryFind v
             | ExprAggregate _ -> None // Aggregates handled after grouping
+            | ExprTerm (Term.Resource id) -> Some id
+            | ExprTerm (Term.Variable v) -> binding.TryFind v
+            | ExprBinaryOp _ -> None // TODO: implement
+            | ExprUnaryOp _ -> None  // TODO: implement
+            | ExprBuiltInCall _ -> None // TODO: implement
 
         let resultsAfterGrouping =
             if query.GroupBy.IsEmpty then

--- a/src/Rdf/QueryProcessor.fs
+++ b/src/Rdf/QueryProcessor.fs
@@ -81,7 +81,8 @@ module QueryProcessor =
                         | GraphLiteral (DecimalLiteral d) -> Some d
                         | GraphLiteral (DoubleLiteral d) -> Some (decimal d)
                         | GraphLiteral (TypedLiteral (tp, v)) when List.contains (tp.ToString()) [Namespaces.XsdInt; Namespaces.XsdInteger; Namespaces.XsdNonNegativeInteger; Namespaces.XsdDecimal] ->
-                            match System.Decimal.TryParse(v) with
+                            let cleanV = if v.Contains("\"") then v.Replace("\"", "") else v
+                            match System.Decimal.TryParse(cleanV, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture) with
                             | true, i -> Some i
                             | _ -> None
                         | _ -> None

--- a/src/Sparql.Parser/ExpressionVisitor.cs
+++ b/src/Sparql.Parser/ExpressionVisitor.cs
@@ -1,0 +1,48 @@
+/*
+    Copyright (C) 2025 Dag Hovland
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+    Contact: hovlanddag@gmail.com
+*/
+
+using DagSemTools.Rdf;
+using DagSemTools.Parser;
+using Microsoft.FSharp.Collections;
+
+namespace DagSemTools.Sparql.Parser;
+
+internal class ExpressionVisitor(TermVisitor termVisitor) : SparqlBaseVisitor<Query.Expression>
+{
+    public override Query.Expression VisitRdfLiteralPrimaryExpression(
+        SparqlParser.RdfLiteralPrimaryExpressionContext context) =>
+            Query.Expression.NewExprTerm(termVisitor.Visit(context.rdfLiteral()));
+    
+
+    public override Query.Expression VisitBracketedPrimaryExpression(
+        SparqlParser.BracketedPrimaryExpressionContext context) =>
+            Visit(context.brackettedExpression().expression());
+
+    public override Query.Expression VisitNumericLiteralPrimaryExpression(
+        SparqlParser.NumericLiteralPrimaryExpressionContext context) =>
+        Query.Expression.NewExprTerm(termVisitor.Visit(context.numericLiteral()));
+    
+    
+    public override Query.Expression VisitBooleanLiteralPrimaryExpression(
+        SparqlParser.BooleanLiteralPrimaryExpressionContext context) =>
+        Query.Expression.NewExprTerm(termVisitor.Visit(context.booleanLiteral()));
+
+    public override Query.Expression VisitVariablePrimaryExpression(
+        SparqlParser.VariablePrimaryExpressionContext context) =>
+        Query.Expression.NewExprTerm(termVisitor.Visit(context.var()));
+
+    public override Query.Expression VisitBuiltInCallPrimaryExpression(
+        SparqlParser.BuiltInCallPrimaryExpressionContext context) =>
+        throw new NotImplementedException("Built-in calls not yet implemented in SPARQL parser");
+
+    public override Query.Expression VisitIriOrFunctionPrimaryExpression(
+        SparqlParser.IriOrFunctionPrimaryExpressionContext context) =>
+        throw new NotImplementedException("IRI or function calls not yet implemented in SPARQL parser");    
+    
+    
+}

--- a/src/Sparql.Parser/ExpressionVisitor.cs
+++ b/src/Sparql.Parser/ExpressionVisitor.cs
@@ -22,9 +22,15 @@ internal class ExpressionVisitor(TermVisitor termVisitor) : SparqlBaseVisitor<Qu
         SparqlParser.RdfLiteralPrimaryExpressionContext context) =>
             Query.Expression.NewExprTerm(termVisitor.Visit(context.rdfLiteral()));
 
+    // Handles brackettedExpression used directly in constraint (FILTER, HAVING, ORDER BY).
+    public override Query.Expression VisitBrackettedExpression(
+        SparqlParser.BrackettedExpressionContext context) =>
+            Visit(context.expression());
+
+    // Handles the labeled alternative in primaryExpression.
     public override Query.Expression VisitBracketedPrimaryExpression(
         SparqlParser.BracketedPrimaryExpressionContext context) =>
-            Visit(context.brackettedExpression().expression());
+            Visit(context.brackettedExpression());
 
     public override Query.Expression VisitNumericLiteralPrimaryExpression(
         SparqlParser.NumericLiteralPrimaryExpressionContext context) =>

--- a/src/Sparql.Parser/ExpressionVisitor.cs
+++ b/src/Sparql.Parser/ExpressionVisitor.cs
@@ -48,12 +48,96 @@ internal class ExpressionVisitor(TermVisitor termVisitor) : SparqlBaseVisitor<Qu
     {
         if (context.aggregate() is { } agg)
             return Visit(agg);
-        throw new NotImplementedException("Built-in calls not yet implemented in SPARQL parser");
+        // EXISTS / NOT EXISTS — group pattern is not an expression; represent with empty args
+        if (context.existsFunc() is not null)
+            return Query.Expression.NewExprBuiltInCall("EXISTS", Microsoft.FSharp.Collections.FSharpList<Query.Expression>.Empty);
+        if (context.notExistsFunc() is not null)
+            return Query.Expression.NewExprBuiltInCall("NOT_EXISTS", Microsoft.FSharp.Collections.FSharpList<Query.Expression>.Empty);
+        // Generic built-in: capture as name + args
+        var name = context.GetChild(0).GetText().ToUpperInvariant();
+        var args = context.expression().Select(Visit).ToList();
+        return Query.Expression.NewExprBuiltInCall(name, Microsoft.FSharp.Collections.ListModule.OfSeq(args));
     }
 
     public override Query.Expression VisitIriOrFunctionPrimaryExpression(
         SparqlParser.IriOrFunctionPrimaryExpressionContext context) =>
         throw new NotImplementedException("IRI or function calls not yet implemented in SPARQL parser");
+
+    // --- Binary/unary expression visitors ---
+
+    public override Query.Expression VisitConditionalOrExpression(SparqlParser.ConditionalOrExpressionContext context)
+    {
+        var operands = context.conditionalAndExpression();
+        if (operands.Length == 1)
+            return Visit(operands[0]);
+        return operands.Skip(1).Aggregate(Visit(operands[0]),
+            (acc, rhs) => Query.Expression.NewExprBinaryOp("||", acc, Visit(rhs)));
+    }
+
+    public override Query.Expression VisitConditionalAndExpression(SparqlParser.ConditionalAndExpressionContext context)
+    {
+        var operands = context.valueLogical();
+        if (operands.Length == 1)
+            return Visit(operands[0]);
+        return operands.Skip(1).Aggregate(Visit(operands[0]),
+            (acc, rhs) => Query.Expression.NewExprBinaryOp("&&", acc, Visit(rhs)));
+    }
+
+    public override Query.Expression VisitRelationalExpression(SparqlParser.RelationalExpressionContext context)
+    {
+        var left = Visit(context.numericExpression(0));
+        if (context.numericExpression().Length == 1)
+            return left;
+        var right = Visit(context.numericExpression(1));
+        // Find the operator token — it's the second child (index 1)
+        var op = context.GetChild(1).GetText();
+        return Query.Expression.NewExprBinaryOp(op, left, right);
+    }
+
+    public override Query.Expression VisitAdditiveExpression(SparqlParser.AdditiveExpressionContext context)
+    {
+        var first = Visit(context.multiplicativeExpression(0));
+        var result = first;
+        // Children: multiplicativeExpression ('+'/'-' multiplicativeExpression)*
+        int multIdx = 1;
+        for (int i = 1; i < context.ChildCount; i++)
+        {
+            var childText = context.GetChild(i).GetText();
+            if (childText == "+" || childText == "-")
+            {
+                var rhs = Visit(context.multiplicativeExpression(multIdx++));
+                result = Query.Expression.NewExprBinaryOp(childText, result, rhs);
+                i++; // skip the rhs child
+            }
+        }
+        return result;
+    }
+
+    public override Query.Expression VisitMultiplicativeExpression(SparqlParser.MultiplicativeExpressionContext context)
+    {
+        var first = Visit(context.unaryExpression(0));
+        var result = first;
+        int unaryIdx = 1;
+        for (int i = 1; i < context.ChildCount; i++)
+        {
+            var childText = context.GetChild(i).GetText();
+            if (childText == "*" || childText == "/")
+            {
+                var rhs = Visit(context.unaryExpression(unaryIdx++));
+                result = Query.Expression.NewExprBinaryOp(childText, result, rhs);
+                i++;
+            }
+        }
+        return result;
+    }
+
+    public override Query.Expression VisitUnaryExpression(SparqlParser.UnaryExpressionContext context)
+    {
+        var firstChild = context.GetChild(0).GetText();
+        if (firstChild == "!" || firstChild == "+" || firstChild == "-")
+            return Query.Expression.NewExprUnaryOp(firstChild, Visit(context.primaryExpression()));
+        return Visit(context.primaryExpression());
+    }
 
     // --- Aggregate visitors (one per labeled alternative in the aggregate rule) ---
 

--- a/src/Sparql.Parser/ExpressionVisitor.cs
+++ b/src/Sparql.Parser/ExpressionVisitor.cs
@@ -6,18 +6,21 @@
     Contact: hovlanddag@gmail.com
 */
 
+using Antlr4.Runtime;
 using DagSemTools.Rdf;
 using DagSemTools.Parser;
 using Microsoft.FSharp.Collections;
+using Microsoft.FSharp.Core;
 
 namespace DagSemTools.Sparql.Parser;
 
 internal class ExpressionVisitor(TermVisitor termVisitor) : SparqlBaseVisitor<Query.Expression>
 {
+    private readonly StringVisitor _stringVisitor = new();
+
     public override Query.Expression VisitRdfLiteralPrimaryExpression(
         SparqlParser.RdfLiteralPrimaryExpressionContext context) =>
             Query.Expression.NewExprTerm(termVisitor.Visit(context.rdfLiteral()));
-    
 
     public override Query.Expression VisitBracketedPrimaryExpression(
         SparqlParser.BracketedPrimaryExpressionContext context) =>
@@ -26,8 +29,7 @@ internal class ExpressionVisitor(TermVisitor termVisitor) : SparqlBaseVisitor<Qu
     public override Query.Expression VisitNumericLiteralPrimaryExpression(
         SparqlParser.NumericLiteralPrimaryExpressionContext context) =>
         Query.Expression.NewExprTerm(termVisitor.Visit(context.numericLiteral()));
-    
-    
+
     public override Query.Expression VisitBooleanLiteralPrimaryExpression(
         SparqlParser.BooleanLiteralPrimaryExpressionContext context) =>
         Query.Expression.NewExprTerm(termVisitor.Visit(context.booleanLiteral()));
@@ -36,13 +38,76 @@ internal class ExpressionVisitor(TermVisitor termVisitor) : SparqlBaseVisitor<Qu
         SparqlParser.VariablePrimaryExpressionContext context) =>
         Query.Expression.NewExprTerm(termVisitor.Visit(context.var()));
 
+    // Delegates to VisitBuiltInCall; the aggregate sub-rule is handled via labeled alternatives.
     public override Query.Expression VisitBuiltInCallPrimaryExpression(
         SparqlParser.BuiltInCallPrimaryExpressionContext context) =>
+        Visit(context.builtInCall());
+
+    // One dispatch check is unavoidable here since builtInCall has 40+ unlabeled alternatives.
+    public override Query.Expression VisitBuiltInCall(SparqlParser.BuiltInCallContext context)
+    {
+        if (context.aggregate() is { } agg)
+            return Visit(agg);
         throw new NotImplementedException("Built-in calls not yet implemented in SPARQL parser");
+    }
 
     public override Query.Expression VisitIriOrFunctionPrimaryExpression(
         SparqlParser.IriOrFunctionPrimaryExpressionContext context) =>
-        throw new NotImplementedException("IRI or function calls not yet implemented in SPARQL parser");    
-    
-    
+        throw new NotImplementedException("IRI or function calls not yet implemented in SPARQL parser");
+
+    // --- Aggregate visitors (one per labeled alternative in the aggregate rule) ---
+
+    public override Query.Expression VisitSumAggregate(SparqlParser.SumAggregateContext context) =>
+        Query.Expression.NewExprAggregate(
+            Query.Aggregate.NewSum(HasDistinct(context), TermFromExpression(context.expression())));
+
+    public override Query.Expression VisitMinAggregate(SparqlParser.MinAggregateContext context) =>
+        Query.Expression.NewExprAggregate(
+            Query.Aggregate.NewMin(HasDistinct(context), TermFromExpression(context.expression())));
+
+    public override Query.Expression VisitMaxAggregate(SparqlParser.MaxAggregateContext context) =>
+        Query.Expression.NewExprAggregate(
+            Query.Aggregate.NewMax(HasDistinct(context), TermFromExpression(context.expression())));
+
+    public override Query.Expression VisitAvgAggregate(SparqlParser.AvgAggregateContext context) =>
+        Query.Expression.NewExprAggregate(
+            Query.Aggregate.NewAvg(HasDistinct(context), TermFromExpression(context.expression())));
+
+    public override Query.Expression VisitSampleAggregate(SparqlParser.SampleAggregateContext context) =>
+        Query.Expression.NewExprAggregate(
+            Query.Aggregate.NewSample(HasDistinct(context), TermFromExpression(context.expression())));
+
+    public override Query.Expression VisitCountAggregate(SparqlParser.CountAggregateContext context)
+    {
+        bool distinct = HasDistinct(context);
+        var term = context.expression() is { } expr
+            ? FSharpOption<Query.Term>.Some(TermFromExpression(expr))
+            : FSharpOption<Query.Term>.None;
+        return Query.Expression.NewExprAggregate(Query.Aggregate.NewCount(distinct, term));
+    }
+
+    public override Query.Expression VisitGroupConcatAggregate(SparqlParser.GroupConcatAggregateContext context)
+    {
+        bool distinct = HasDistinct(context);
+        var term = TermFromExpression(context.expression());
+        var separator = context.stringLiteral() is { } sep
+            ? FSharpOption<string>.Some(_stringVisitor.Visit(sep))
+            : FSharpOption<string>.None;
+        return Query.Expression.NewExprAggregate(Query.Aggregate.NewGroupConcat(distinct, term, separator));
+    }
+
+    // --- Helpers ---
+
+    private static bool HasDistinct(ParserRuleContext context) =>
+        context.children?.Any(c => c.GetText() == "DISTINCT") ?? false;
+
+    private Query.Term TermFromExpression(SparqlParser.ExpressionContext ctx)
+    {
+        var expr = Visit(ctx);
+        return expr switch
+        {
+            Query.Expression.ExprTerm t => t.Item,
+            _ => throw new NotImplementedException($"Only simple term expressions supported in aggregates, got: {ctx.GetText()}")
+        };
+    }
 }

--- a/src/Sparql.Parser/GroupPatternVisitor.cs
+++ b/src/Sparql.Parser/GroupPatternVisitor.cs
@@ -8,16 +8,22 @@
 
 using DagSemTools.Rdf;
 using Microsoft.FSharp.Collections;
+using DagSemTools.Parser;
 
 namespace DagSemTools.Sparql.Parser;
 
 internal class GroupPatternVisitor(TermVisitor termVisitor) : SparqlBaseVisitor<IEnumerable<Query.QueryComponent>>
 {
     private readonly PropertyPathVisitor _propertyPathVisitor = new(termVisitor);
+    private readonly ExpressionVisitor _expressionVisitor = new(termVisitor);
 
     public override IEnumerable<Query.QueryComponent> VisitGroupGraphPattern(
         SparqlParser.GroupGraphPatternContext context)
-        => Visit(context.groupGraphPatternSub());
+    {
+        if (context.subSelect() is { } sub)
+            return Visit(sub);
+        return Visit(context.groupGraphPatternSub());
+    }
 
     public override IEnumerable<Query.QueryComponent> VisitGroupGraphPatternSub(SparqlParser.GroupGraphPatternSubContext context)
     {
@@ -43,6 +49,18 @@ internal class GroupPatternVisitor(TermVisitor termVisitor) : SparqlBaseVisitor<
     {
         if (context.optionalGraphPattern() != null)
             return Visit(context.optionalGraphPattern());
+        if (context.groupOrUnionGraphPattern() != null)
+            return Visit(context.groupOrUnionGraphPattern());
+        if (context.filter() != null)
+            return Visit(context.filter());
+        if (context.minusGraphPattern() != null)
+            return Visit(context.minusGraphPattern());
+        if (context.bind() != null)
+            return Visit(context.bind());
+        if (context.inlineData() != null)
+            return Visit(context.inlineData());
+        if (context.graphGraphPattern() != null)
+            return Visit(context.graphGraphPattern());
         throw new NotImplementedException($"GraphPatternNotTriples is not yet fully parsed. {context.GetText()} is not supported. Sorry");
     }
 
@@ -50,6 +68,118 @@ internal class GroupPatternVisitor(TermVisitor termVisitor) : SparqlBaseVisitor<
     {
         var group = Visit(context.groupGraphPattern());
         return new[] { Query.QueryComponent.NewOptional(Query.OptionalPattern.NewOptional(ListModule.OfSeq(group))) };
+    }
+
+    public override IEnumerable<Query.QueryComponent> VisitGroupOrUnionGraphPattern(SparqlParser.GroupOrUnionGraphPatternContext context)
+    {
+        var groups = context.groupGraphPattern()
+            .Select(g => ListModule.OfSeq(Visit(g)))
+            .ToList();
+        if (groups.Count == 1)
+            return groups[0];
+        return new[] { Query.QueryComponent.NewUnion(ListModule.OfSeq(groups)) };
+    }
+
+    public override IEnumerable<Query.QueryComponent> VisitFilter(SparqlParser.FilterContext context)
+    {
+        var expr = _expressionVisitor.Visit(context.constraint());
+        return new[] { Query.QueryComponent.NewFilter(expr) };
+    }
+
+    public override IEnumerable<Query.QueryComponent> VisitMinusGraphPattern(SparqlParser.MinusGraphPatternContext context)
+    {
+        var group = ListModule.OfSeq(Visit(context.groupGraphPattern()));
+        return new[] { Query.QueryComponent.NewMinus(group) };
+    }
+
+    public override IEnumerable<Query.QueryComponent> VisitBind(SparqlParser.BindContext context)
+    {
+        var expr = _expressionVisitor.Visit(context.expression());
+        var varName = ParserUtils.GetVariableName(context.var().GetText());
+        return new[] { Query.QueryComponent.NewBind(expr, varName) };
+    }
+
+    public override IEnumerable<Query.QueryComponent> VisitInlineData(SparqlParser.InlineDataContext context)
+    {
+        var dataBlock = context.dataBlock();
+        if (dataBlock.inlineDataOneVar() is { } oneVar)
+        {
+            var varName = ParserUtils.GetVariableName(oneVar.var().GetText());
+            var vars = new List<string> { varName };
+            var rows = oneVar.dataBlockValue()
+                .Select(dbv => new List<Query.Term> { ParseDataBlockValue(dbv) })
+                .Select(r => ListModule.OfSeq(r))
+                .ToList();
+            return new[] { Query.QueryComponent.NewValues(ListModule.OfSeq(vars), ListModule.OfSeq(rows)) };
+        }
+        if (dataBlock.inlineDataFull() is { } full)
+        {
+            var vars = full.var().Select(v => ParserUtils.GetVariableName(v.GetText())).ToList();
+            // Each row is a parenthesized group of dataBlockValues
+            var rows = new List<Microsoft.FSharp.Collections.FSharpList<Query.Term>>();
+            // Children: NIL or '(' var* ')' then '{' ( '(' dataBlockValue* ')' | NIL )* '}'
+            // We use the grammar structure: the row groups are inside braces
+            // Parse by collecting consecutive dataBlockValue sequences from children
+            var allDbvGroups = new List<List<Query.Term>>();
+            for (int i = 0; i < full.ChildCount; i++)
+            {
+                var child = full.GetChild(i);
+                if (child.GetText() == "(")
+                {
+                    var row = new List<Query.Term>();
+                    i++;
+                    while (i < full.ChildCount && full.GetChild(i).GetText() != ")")
+                    {
+                        if (full.GetChild(i) is SparqlParser.DataBlockValueContext dbv)
+                            row.Add(ParseDataBlockValue(dbv));
+                        i++;
+                    }
+                    allDbvGroups.Add(row);
+                }
+            }
+            // Skip first group which is the variable list; use remaining groups as rows
+            // Actually the var list uses var() not dataBlockValue, so allDbvGroups are all data rows
+            return new[] { Query.QueryComponent.NewValues(ListModule.OfSeq(vars), ListModule.OfSeq(allDbvGroups.Select(ListModule.OfSeq))) };
+        }
+        return Array.Empty<Query.QueryComponent>();
+    }
+
+    private Query.Term ParseDataBlockValue(SparqlParser.DataBlockValueContext context)
+    {
+        if (context.iri() != null) return termVisitor.Visit(context.iri());
+        if (context.rdfLiteral() != null) return termVisitor.Visit(context.rdfLiteral());
+        if (context.numericLiteral() != null) return termVisitor.Visit(context.numericLiteral());
+        if (context.booleanLiteral() != null) return termVisitor.Visit(context.booleanLiteral());
+        // UNDEF maps to a special unbound variable placeholder
+        return Query.Term.NewVariable("__UNDEF__");
+    }
+
+    public override IEnumerable<Query.QueryComponent> VisitGraphGraphPattern(SparqlParser.GraphGraphPatternContext context)
+    {
+        // Treat named graph patterns as plain groups for now
+        return Visit(context.groupGraphPattern());
+    }
+
+    public override IEnumerable<Query.QueryComponent> VisitSubSelect(SparqlParser.SubSelectContext context)
+    {
+        var parsedVars = context.selectClause().projection()
+            .Select(v => new ProjectionVisitor(termVisitor).Visit(v))
+            .ToList();
+        var parsedWhereClause = Visit(context.whereClause().groupGraphPattern());
+        var solutionModifier = context.solutionModifier();
+        var groupBy = new List<Query.Expression>();
+        if (solutionModifier.groupClause() != null)
+        {
+            foreach (var groupCondition in solutionModifier.groupClause().groupCondition())
+            {
+                if (groupCondition.var() != null)
+                    groupBy.Add(Query.Expression.NewExprVariable(ParserUtils.GetVariableName(groupCondition.var().GetText())));
+                else if (groupCondition.expression() != null)
+                    groupBy.Add(_expressionVisitor.Visit(groupCondition.expression()));
+            }
+        }
+        var subQuery = new Query.SelectQuery(ListModule.OfSeq(parsedVars), ListModule.OfSeq(parsedWhereClause), ListModule.OfSeq(groupBy));
+        return new[] { Query.QueryComponent.NewSubquery(subQuery) };
     }
 
     public override IEnumerable<Query.QueryComponent> VisitTriplesBlock(SparqlParser.TriplesBlockContext context)

--- a/src/Sparql.Parser/PathVisitor.cs
+++ b/src/Sparql.Parser/PathVisitor.cs
@@ -18,4 +18,29 @@ internal class PathVisitor(TermVisitor termVisitor) : SparqlBaseVisitor<Query.Te
         SparqlParser.IriContext context)
         => termVisitor.VisitIri(context);
 
+    // path → pathAlternative (just delegate)
+    public override Query.Term VisitPath(SparqlParser.PathContext context)
+        => Visit(context.pathAlternative());
+
+    // pathAlternative: pathSequence ( '|' pathSequence )*
+    // For now, return the first alternative (simplified — full support requires PropertyPath type)
+    public override Query.Term VisitPathAlternative(SparqlParser.PathAlternativeContext context)
+        => Visit(context.pathSequence(0));
+
+    // pathSequence: pathEltOrInverse ( '/' pathEltOrInverse )*
+    // For now, return the first element (simplified)
+    public override Query.Term VisitPathSequence(SparqlParser.PathSequenceContext context)
+        => Visit(context.pathEltOrInverse(0));
+
+    // pathEltOrInverse: pathElt | '^' pathElt
+    public override Query.Term VisitPathEltOrInverse(SparqlParser.PathEltOrInverseContext context)
+        => Visit(context.pathElt());
+
+    // pathElt: pathPrimary pathMod?
+    public override Query.Term VisitPathElt(SparqlParser.PathEltContext context)
+        => Visit(context.pathPrimary());
+
+    // pathPrimary '(' path ')' #PathGroup
+    public override Query.Term VisitPathGroup(SparqlParser.PathGroupContext context)
+        => Visit(context.path());
 }

--- a/src/Sparql.Parser/ProjectionVisitor.cs
+++ b/src/Sparql.Parser/ProjectionVisitor.cs
@@ -6,13 +6,22 @@
     Contact: hovlanddag@gmail.com
 */
 
+using DagSemTools.Rdf;
 using DagSemTools.Parser;
 using Microsoft.FSharp.Collections;
 
 namespace DagSemTools.Sparql.Parser;
 
-internal class ProjectionVisitor() : SparqlBaseVisitor<string>
+internal class ProjectionVisitor() : SparqlBaseVisitor<Query.ProjectionElement>
 {
-    public override string VisitVar(SparqlParser.VarContext context)
-        => ParserUtils.GetVariableName(context.GetText());
+    private ExpressionVisitor _expressionVisitor = new();
+    public override Query.ProjectionElement VisitVar(SparqlParser.VarContext context)
+        => Query.ProjectionElement.NewProjectVariable(ParserUtils.GetVariableName(context.GetText()));
+
+    public override Query.ProjectionElement VisitVariableAlias(SparqlParser.VariableAliasContext context)
+    {
+        var expr = _expressionVisitor.Visit(context.expression());
+        var alias = ParserUtils.GetVariableName(context.var().GetText());
+        return Query.ProjectionElement.NewProjectExpression(expr, alias);
+    }
 }

--- a/src/Sparql.Parser/ProjectionVisitor.cs
+++ b/src/Sparql.Parser/ProjectionVisitor.cs
@@ -12,9 +12,9 @@ using Microsoft.FSharp.Collections;
 
 namespace DagSemTools.Sparql.Parser;
 
-internal class ProjectionVisitor() : SparqlBaseVisitor<Query.ProjectionElement>
+internal class ProjectionVisitor(TermVisitor termVisitor) : SparqlBaseVisitor<Query.ProjectionElement>
 {
-    private ExpressionVisitor _expressionVisitor = new();
+    private ExpressionVisitor _expressionVisitor = new(termVisitor);
     public override Query.ProjectionElement VisitVar(SparqlParser.VarContext context)
         => Query.ProjectionElement.NewProjectVariable(ParserUtils.GetVariableName(context.GetText()));
 

--- a/src/Sparql.Parser/SparqlListener.cs
+++ b/src/Sparql.Parser/SparqlListener.cs
@@ -113,7 +113,7 @@ internal class SparqlListener : SparqlBaseListener
     {
         var projection = context.selectClause();
         var parsedVars = projection.projection().
-            Select(v => new ProjectionVisitor().Visit(v))
+            Select(v => new ProjectionVisitor(_termVisitor).Visit(v))
             .ToList();
         var whereClause = context.whereClause().groupGraphPattern();
         var parsedWhereClause = _groupPatternVisitor.Visit(whereClause);
@@ -122,7 +122,7 @@ internal class SparqlListener : SparqlBaseListener
         var groupBy = new List<Query.Expression>();
         if (solutionModifier.groupClause() != null)
         {
-            var expressionVisitor = new ExpressionVisitor();
+            var expressionVisitor = new ExpressionVisitor(_termVisitor);
             foreach (var groupCondition in solutionModifier.groupClause().groupCondition())
             {
                 if (groupCondition.var() != null)

--- a/src/Sparql.Parser/SparqlListener.cs
+++ b/src/Sparql.Parser/SparqlListener.cs
@@ -118,7 +118,34 @@ internal class SparqlListener : SparqlBaseListener
         var whereClause = context.whereClause().groupGraphPattern();
         var parsedWhereClause = _groupPatternVisitor.Visit(whereClause);
         var solutionModifier = context.solutionModifier();
-        _result = new Query.SelectQuery(ListModule.OfSeq(parsedVars), ListModule.OfSeq(parsedWhereClause));
+
+        var groupBy = new List<Query.Expression>();
+        if (solutionModifier.groupClause() != null)
+        {
+            var expressionVisitor = new ExpressionVisitor();
+            foreach (var groupCondition in solutionModifier.groupClause().groupCondition())
+            {
+                if (groupCondition.var() != null)
+                {
+                    groupBy.Add(Query.Expression.NewExprVariable(ParserUtils.GetVariableName(groupCondition.var().GetText())));
+                }
+                else if (groupCondition.expression() != null)
+                {
+                    groupBy.Add(expressionVisitor.Visit(groupCondition.expression()));
+                }
+                else if (groupCondition.builtInCall() != null)
+                {
+                    groupBy.Add(expressionVisitor.Visit(groupCondition.builtInCall()));
+                }
+                else if (groupCondition.functionCall() != null)
+                {
+                    // Function call not fully supported in Query.Expression yet, but we can try
+                    // For now, we might need to extend Expression if we want to support it properly
+                }
+            }
+        }
+
+        _result = new Query.SelectQuery(ListModule.OfSeq(parsedVars), ListModule.OfSeq(parsedWhereClause), ListModule.OfSeq(groupBy));
     }
 
 

--- a/test/Api.Tests/TestApi.cs
+++ b/test/Api.Tests/TestApi.cs
@@ -482,4 +482,36 @@ public class TestApi(ITestOutputHelper output)
 
         return graph;
     }
+
+    [Fact(Skip = "Aggregates and GROUP BY are not yet supported in the QueryProcessor")]
+    public void TestSparqlAggregate()
+    {
+        var data = """
+                   PREFIX : <http://books.example/>
+                   :org1 :hasBook :book1 .
+                   :book1 :price 10 .
+                   :org1 :hasBook :book2 .
+                   :book2 :price 20 .
+                   :org2 :hasBook :book3 .
+                   :book3 :price 30 .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX : <http://books.example/>
+                          SELECT (SUM(?lprice) AS ?totalPrice)
+                          WHERE {
+                            ?org :hasBook ?book .
+                            ?book :price ?lprice .
+                          }
+                          GROUP BY ?org
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        answers.Count.Should().Be(2);
+
+        var org1Result = answers.FirstOrDefault(a => a["totalPrice"].ToString().Equals("30"));
+        var org2Result = answers.FirstOrDefault(a => a["totalPrice"].ToString().Equals("30"));
+        org1Result.Should().NotBeNull();
+        org2Result.Should().NotBeNull();
+    }
 }

--- a/test/Api.Tests/TestApi.cs
+++ b/test/Api.Tests/TestApi.cs
@@ -655,6 +655,659 @@ public class TestApi(ITestOutputHelper output)
         answers.Count.Should().Be(1);
     }
 
+    /// <summary>
+    /// SPARQL 1.2 spec §6.2: OPTIONAL with inner FILTER
+    /// </summary>
+    [Fact(Skip = "FILTER inside OPTIONAL not yet evaluated")]
+    public void TestSparqlOptionalWithFilter()
+    {
+        var data = """
+                   PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                   _:a foaf:name "Alice" ; foaf:mbox <mailto:alice@work.example> .
+                   _:b foaf:name "Bob" ; foaf:mbox <mailto:bob@home.example> .
+                   _:c foaf:name "Carol" .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                          SELECT ?name ?mbox
+                          WHERE {
+                            ?x foaf:name ?name .
+                            OPTIONAL { ?x foaf:mbox ?mbox
+                                       FILTER regex(str(?mbox), "@work") }
+                          }
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        // Carol has no mbox, Alice's mbox matches @work, Bob's mbox does not match
+        answers.Count.Should().Be(3);
+        var aliceAnswer = answers.Single(a => a["name"].ToString() == "Alice");
+        aliceAnswer.ContainsKey("mbox").Should().BeTrue();
+        var bobAnswer = answers.Single(a => a["name"].ToString() == "Bob");
+        bobAnswer.ContainsKey("mbox").Should().BeFalse();
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §6.3: Multiple OPTIONAL blocks
+    /// </summary>
+    [Fact(Skip = "Multiple OPTIONAL not yet fully evaluated")]
+    public void TestSparqlMultipleOptionals()
+    {
+        var data = """
+                   PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                   _:a foaf:name "Alice" ; foaf:mbox <mailto:alice@example.org> ; foaf:homepage <http://alice.example.org/> .
+                   _:b foaf:name "Bob" ; foaf:mbox <mailto:bob@example.org> .
+                   _:c foaf:name "Carol" .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                          SELECT ?name ?mbox ?hpage
+                          WHERE {
+                            ?x foaf:name  ?name .
+                            OPTIONAL { ?x foaf:mbox  ?mbox } .
+                            OPTIONAL { ?x foaf:homepage ?hpage }
+                          }
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        answers.Count.Should().Be(3);
+        var aliceAnswer = answers.Single(a => a["name"].ToString() == "Alice");
+        aliceAnswer.ContainsKey("mbox").Should().BeTrue();
+        aliceAnswer.ContainsKey("hpage").Should().BeTrue();
+        var bobAnswer = answers.Single(a => a["name"].ToString() == "Bob");
+        bobAnswer.ContainsKey("mbox").Should().BeTrue();
+        bobAnswer.ContainsKey("hpage").Should().BeFalse();
+        var carolAnswer = answers.Single(a => a["name"].ToString() == "Carol");
+        carolAnswer.ContainsKey("mbox").Should().BeFalse();
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §8.1: FILTER NOT EXISTS
+    /// </summary>
+    [Fact(Skip = "NOT EXISTS is not yet implemented")]
+    public void TestSparqlNotExists()
+    {
+        var data = """
+                   PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                   PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                   <http://example.org/alice> rdf:type foaf:Person ; foaf:name "Alice" .
+                   <http://example.org/bob> rdf:type foaf:Person .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                          PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                          SELECT ?person
+                          WHERE {
+                            ?person rdf:type foaf:Person .
+                            FILTER NOT EXISTS { ?person foaf:name ?name }
+                          }
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        // Only bob has no foaf:name
+        answers.Count.Should().Be(1);
+        answers[0]["person"].ToString().Should().Contain("bob");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §9.3.2: Property path alternative using |
+    /// </summary>
+    [Fact(Skip = "Property path alternatives are not yet implemented")]
+    public void TestSparqlPathAlternative()
+    {
+        var data = """
+                   PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                   PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                   <http://example.org/alice> foaf:name "Alice" .
+                   <http://example.org/bob> rdfs:label "Bob" .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                          PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                          SELECT ?x ?name
+                          WHERE {
+                            ?x foaf:name|rdfs:label ?name .
+                          }
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        answers.Count.Should().Be(2);
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §9.4: Inverse property path using ^
+    /// </summary>
+    [Fact(Skip = "Inverse property paths are not yet implemented")]
+    public void TestSparqlPathInverse()
+    {
+        var data = """
+                   PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                   <http://example.org/alice> foaf:knows <http://example.org/bob> .
+                   <http://example.org/alice> foaf:knows <http://example.org/carol> .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                          SELECT ?x
+                          WHERE {
+                            ?x ^foaf:knows <http://example.org/alice> .
+                          }
+                          """;
+        // Inverse: ?x is known-by alice, i.e. alice foaf:knows ?x
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        answers.Count.Should().Be(2);
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §9.5: One-or-more path (+)
+    /// </summary>
+    [Fact(Skip = "Arbitrary length property paths are not yet implemented")]
+    public void TestSparqlPathOneOrMore()
+    {
+        var data = """
+                   PREFIX : <http://example.org/>
+                   :a :knows :b .
+                   :b :knows :c .
+                   :c :knows :d .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX : <http://example.org/>
+                          SELECT ?x
+                          WHERE { :a :knows+ ?x }
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        // Transitively reachable: b, c, d
+        answers.Count.Should().Be(3);
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §9.5: Zero-or-more path (*)
+    /// </summary>
+    [Fact(Skip = "Arbitrary length property paths are not yet implemented")]
+    public void TestSparqlPathZeroOrMore()
+    {
+        var data = """
+                   PREFIX : <http://example.org/>
+                   :a :subClassOf :b .
+                   :b :subClassOf :c .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX : <http://example.org/>
+                          SELECT ?x
+                          WHERE { :a :subClassOf* ?x }
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        // Zero or more: a (self), b, c
+        answers.Count.Should().Be(3);
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §15.1: ORDER BY — results should be ordered
+    /// </summary>
+    [Fact(Skip = "ORDER BY is not yet implemented")]
+    public void TestSparqlOrderBy()
+    {
+        var data = """
+                   PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                   _:a foaf:name "Charlie" .
+                   _:b foaf:name "Alice" .
+                   _:c foaf:name "Bob" .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                          SELECT ?name
+                          WHERE { ?x foaf:name ?name }
+                          ORDER BY ?name
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        answers.Count.Should().Be(3);
+        var names = answers.Select(a => a["name"].ToString()).ToList();
+        names.Should().BeInAscendingOrder();
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §15.1: ORDER BY DESC
+    /// </summary>
+    [Fact(Skip = "ORDER BY is not yet implemented")]
+    public void TestSparqlOrderByDesc()
+    {
+        var data = """
+                   PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                   _:a foaf:name "Charlie" .
+                   _:b foaf:name "Alice" .
+                   _:c foaf:name "Bob" .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                          SELECT ?name
+                          WHERE { ?x foaf:name ?name }
+                          ORDER BY DESC(?name)
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        answers.Count.Should().Be(3);
+        var names = answers.Select(a => a["name"].ToString()).ToList();
+        names.Should().BeInDescendingOrder();
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §15.3: LIMIT
+    /// </summary>
+    [Fact(Skip = "LIMIT is not yet implemented")]
+    public void TestSparqlLimit()
+    {
+        var data = """
+                   PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                   _:a foaf:name "Alice" .
+                   _:b foaf:name "Bob" .
+                   _:c foaf:name "Carol" .
+                   _:d foaf:name "Dave" .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                          SELECT ?name
+                          WHERE { ?x foaf:name ?name }
+                          LIMIT 2
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        answers.Count.Should().Be(2);
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §15.4: OFFSET
+    /// </summary>
+    [Fact(Skip = "OFFSET is not yet implemented")]
+    public void TestSparqlOffset()
+    {
+        var data = """
+                   PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                   _:a foaf:name "Alice" .
+                   _:b foaf:name "Bob" .
+                   _:c foaf:name "Carol" .
+                   _:d foaf:name "Dave" .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                          SELECT ?name
+                          WHERE { ?x foaf:name ?name }
+                          ORDER BY ?name
+                          LIMIT 2
+                          OFFSET 2
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        answers.Count.Should().Be(2);
+        var names = answers.Select(a => a["name"].ToString()).ToList();
+        names.Should().Contain("Carol");
+        names.Should().Contain("Dave");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §15.5: DISTINCT modifier removes duplicate rows
+    /// </summary>
+    [Fact(Skip = "DISTINCT is not yet implemented")]
+    public void TestSparqlDistinct()
+    {
+        var data = """
+                   PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                   _:a foaf:name "Alice" ; foaf:nick "Ali" .
+                   _:b foaf:name "Alice" ; foaf:nick "Allie" .
+                   _:c foaf:name "Bob" .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                          SELECT DISTINCT ?name
+                          WHERE { ?x foaf:name ?name }
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        // Two subjects have name "Alice" but DISTINCT collapses them
+        answers.Count.Should().Be(2);
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §11.2: HAVING clause filters aggregate results
+    /// </summary>
+    [Fact(Skip = "HAVING is not yet implemented")]
+    public void TestSparqlHaving()
+    {
+        var data = """
+                   PREFIX : <http://books.example/>
+                   :org1 :hasBook :book1 .
+                   :book1 :price 5 .
+                   :org1 :hasBook :book2 .
+                   :book2 :price 8 .
+                   :org2 :hasBook :book3 .
+                   :book3 :price 30 .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX : <http://books.example/>
+                          SELECT ?org (SUM(?lprice) AS ?totalPrice)
+                          WHERE {
+                            ?org :hasBook ?book .
+                            ?book :price ?lprice .
+                          }
+                          GROUP BY ?org
+                          HAVING (SUM(?lprice) > 20)
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        // org1 total = 13 (filtered out), org2 total = 30 (kept)
+        answers.Count.Should().Be(1);
+        answers[0]["totalPrice"].ToString().Should().Be("IntegerLiteral(30)");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §17.2: IN expression
+    /// </summary>
+    [Fact(Skip = "IN expression is not yet evaluated")]
+    public void TestSparqlFilterIn()
+    {
+        var data = """
+                   PREFIX dc: <http://purl.org/dc/elements/1.1/>
+                   PREFIX : <http://example.org/book/>
+                   :book1 dc:title "SPARQL Tutorial" .
+                   :book2 dc:title "The Semantic Web" .
+                   :book3 dc:title "Programming .NET" .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX dc: <http://purl.org/dc/elements/1.1/>
+                          SELECT ?title
+                          WHERE {
+                            ?book dc:title ?title .
+                            FILTER (?title IN ("SPARQL Tutorial", "The Semantic Web"))
+                          }
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        answers.Count.Should().Be(2);
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §17.2: NOT IN expression
+    /// </summary>
+    [Fact(Skip = "NOT IN expression is not yet evaluated")]
+    public void TestSparqlFilterNotIn()
+    {
+        var data = """
+                   PREFIX dc: <http://purl.org/dc/elements/1.1/>
+                   PREFIX : <http://example.org/book/>
+                   :book1 dc:title "SPARQL Tutorial" .
+                   :book2 dc:title "The Semantic Web" .
+                   :book3 dc:title "Programming .NET" .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX dc: <http://purl.org/dc/elements/1.1/>
+                          SELECT ?title
+                          WHERE {
+                            ?book dc:title ?title .
+                            FILTER (?title NOT IN ("SPARQL Tutorial"))
+                          }
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        answers.Count.Should().Be(2);
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §17.4.3: REGEX string filter
+    /// </summary>
+    [Fact(Skip = "REGEX function is not yet evaluated")]
+    public void TestSparqlFilterRegex()
+    {
+        var data = """
+                   PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                   _:a foaf:name "Alice" .
+                   _:b foaf:name "Bob" .
+                   _:c foaf:name "Alicia" .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                          SELECT ?name
+                          WHERE {
+                            ?x foaf:name ?name .
+                            FILTER regex(?name, "^Al", "i")
+                          }
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        answers.Count.Should().Be(2);
+        var names = answers.Select(a => a["name"].ToString()).ToList();
+        names.Should().Contain("Alice");
+        names.Should().Contain("Alicia");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §17.4.1: BOUND function
+    /// </summary>
+    [Fact(Skip = "BOUND function is not yet evaluated")]
+    public void TestSparqlBound()
+    {
+        var data = """
+                   PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                   _:a foaf:name "Alice" ; foaf:mbox <mailto:alice@example.org> .
+                   _:b foaf:name "Bob" .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                          SELECT ?name
+                          WHERE {
+                            ?x foaf:name ?name .
+                            OPTIONAL { ?x foaf:mbox ?mbox }
+                            FILTER (BOUND(?mbox))
+                          }
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        // Only Alice has mbox
+        answers.Count.Should().Be(1);
+        answers[0]["name"].ToString().Should().Be("Alice");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §17.4.1: IF function
+    /// </summary>
+    [Fact(Skip = "IF function is not yet evaluated")]
+    public void TestSparqlIf()
+    {
+        var data = """
+                   PREFIX ns: <http://example.org/ns#>
+                   <http://example.org/s1> ns:value 5 .
+                   <http://example.org/s2> ns:value 15 .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX ns: <http://example.org/ns#>
+                          SELECT ?s (IF(?x > 10, "big", "small") AS ?size)
+                          WHERE { ?s ns:value ?x }
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        answers.Count.Should().Be(2);
+        var s1 = answers.Single(a => a["s"].ToString().Contains("s1"));
+        s1["size"].ToString().Should().Be("small");
+        var s2 = answers.Single(a => a["s"].ToString().Contains("s2"));
+        s2["size"].ToString().Should().Be("big");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §17.4.1: COALESCE returns first non-error argument
+    /// </summary>
+    [Fact(Skip = "COALESCE function is not yet evaluated")]
+    public void TestSparqlCoalesce()
+    {
+        var data = """
+                   PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                   _:a foaf:name "Alice" ; foaf:mbox <mailto:alice@example.org> .
+                   _:b foaf:name "Bob" .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                          SELECT ?name (COALESCE(str(?mbox), "no email") AS ?contact)
+                          WHERE {
+                            ?x foaf:name ?name .
+                            OPTIONAL { ?x foaf:mbox ?mbox }
+                          }
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        answers.Count.Should().Be(2);
+        var bobAnswer = answers.Single(a => a["name"].ToString() == "Bob");
+        bobAnswer["contact"].ToString().Should().Be("no email");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §13.3: GRAPH pattern for named graph query
+    /// </summary>
+    [Fact(Skip = "Named graph GRAPH patterns are not yet implemented")]
+    public void TestSparqlNamedGraph()
+    {
+        var data = """
+                   @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+                   <http://example.org/graph1> {
+                     <http://example.org/alice> foaf:name "Alice" .
+                   }
+                   <http://example.org/graph2> {
+                     <http://example.org/bob> foaf:name "Bob" .
+                   }
+                   """;
+        var dataset = TriGParser.Parse(data, new StringWriter());
+        var queryString = """
+                          PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                          SELECT ?graph ?name
+                          WHERE {
+                            GRAPH ?graph {
+                              ?x foaf:name ?name .
+                            }
+                          }
+                          """;
+        var answers = dataset.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        answers.Count.Should().Be(2);
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §13.3: GRAPH with specific named graph IRI
+    /// </summary>
+    [Fact(Skip = "Named graph GRAPH patterns are not yet implemented")]
+    public void TestSparqlSpecificNamedGraph()
+    {
+        var data = """
+                   @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+                   <http://example.org/graph1> {
+                     <http://example.org/alice> foaf:name "Alice" .
+                   }
+                   <http://example.org/graph2> {
+                     <http://example.org/bob> foaf:name "Bob" .
+                   }
+                   """;
+        var dataset = TriGParser.Parse(data, new StringWriter());
+        var queryString = """
+                          PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                          SELECT ?name
+                          WHERE {
+                            GRAPH <http://example.org/graph1> {
+                              ?x foaf:name ?name .
+                            }
+                          }
+                          """;
+        var answers = dataset.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        answers.Count.Should().Be(1);
+        answers[0]["name"].ToString().Should().Be("Alice");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §11.3: COUNT aggregate without GROUP BY
+    /// </summary>
+    [Fact(Skip = "COUNT aggregate evaluation is not yet verified")]
+    public void TestSparqlCount()
+    {
+        var data = """
+                   PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                   _:a foaf:name "Alice" .
+                   _:b foaf:name "Bob" .
+                   _:c foaf:name "Carol" .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                          SELECT (COUNT(?x) AS ?count)
+                          WHERE { ?x foaf:name ?name }
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        answers.Count.Should().Be(1);
+        answers[0]["count"].ToString().Should().Be("IntegerLiteral(3)");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §17.4.3: CONCAT string function in SELECT
+    /// </summary>
+    [Fact(Skip = "CONCAT function is not yet evaluated")]
+    public void TestSparqlConcat()
+    {
+        var data = """
+                   PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                   _:a foaf:givenName "John" ; foaf:familyName "Doe" .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                          SELECT (CONCAT(?gn, " ", ?fn) AS ?name)
+                          WHERE { ?x foaf:givenName ?gn ; foaf:familyName ?fn }
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        answers.Count.Should().Be(1);
+        answers[0]["name"].ToString().Should().Be("John Doe");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §16.1.1: SELECT * wildcard projects all variables
+    /// </summary>
+    [Fact(Skip = "SELECT * wildcard projection is not yet implemented")]
+    public void TestSparqlSelectStar()
+    {
+        var data = """
+                   PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                   _:a foaf:name "Alice" ; foaf:mbox <mailto:alice@example.org> .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                          SELECT *
+                          WHERE { ?x foaf:name ?name ; foaf:mbox ?mbox }
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        answers.Count.Should().Be(1);
+        var answer = answers[0];
+        answer.ContainsKey("name").Should().BeTrue();
+        answer.ContainsKey("mbox").Should().BeTrue();
+    }
+
     private IDataset ParseTurtleData(string data)
     {
         var writer = new StringWriter();

--- a/test/Api.Tests/TestApi.cs
+++ b/test/Api.Tests/TestApi.cs
@@ -568,10 +568,21 @@ public class TestApi(ITestOutputHelper output)
                           SELECT  ?title ?price
                           WHERE   { ?x ns:price ?price .
                                     ?x dc:title ?title .
-                                    FILTER (?price < 30) .
                                   }
                           """;
         var answers = graph.AnswerSelectQuery(queryString).ToList();
+        answers.Should().HaveCount(2);
+
+        queryString = """
+                          PREFIX  dc:  <http://purl.org/dc/elements/1.1/>
+                          PREFIX  ns:  <http://example.org/ns#>
+                          SELECT  ?title ?price
+                          WHERE   { ?x ns:price ?price .
+                                    ?x dc:title ?title .
+                                    FILTER (?price < 30) .
+                                  }
+                          """;
+        answers = graph.AnswerSelectQuery(queryString).ToList();
         Assert.NotNull(answers);
         answers.Count.Should().Be(1);
     }

--- a/test/Api.Tests/TestApi.cs
+++ b/test/Api.Tests/TestApi.cs
@@ -469,6 +469,192 @@ public class TestApi(ITestOutputHelper output)
         }
     }
 
+    [Fact(Skip = "Select Expressions are not yet supported")]
+    public void TestSparqlSelectExpressions()
+    {
+        var data = """
+                   PREFIX dc:   <http://purl.org/dc/elements/1.1/>
+                   PREFIX ns:   <http://example.org/ns#>
+                   <http://example.org/book/book1> dc:title "SPARQL Tutorial" ; ns:price 42 ; ns:discount 0.2 .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX dc:   <http://purl.org/dc/elements/1.1/>
+                          PREFIX ns:   <http://example.org/ns#>
+                          SELECT ?title (?p*(1-?discount) AS ?price)
+                          WHERE { ?book dc:title ?title ; ns:price ?p ; ns:discount ?discount }
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        answers.Count.Should().Be(1);
+    }
+
+    [Fact(Skip = "UNION is not yet supported")]
+    public void TestSparqlUnion()
+    {
+        var data = """
+                   PREFIX dc10:  <http://purl.org/dc/elements/1.0/>
+                   PREFIX dc11:  <http://purl.org/dc/elements/1.1/>
+                   _:a dc10:title "SPARQL 1.0" .
+                   _:b dc11:title "SPARQL 1.1" .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX dc10:  <http://purl.org/dc/elements/1.0/>
+                          PREFIX dc11:  <http://purl.org/dc/elements/1.1/>
+                          SELECT ?title
+                          WHERE  { { ?book dc10:title ?title } UNION { ?book dc11:title ?title } }
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        answers.Count.Should().Be(2);
+    }
+
+    [Fact(Skip = "FILTER is not yet supported")]
+    public void TestSparqlFilter()
+    {
+        var data = """
+                   PREFIX dc:  <http://purl.org/dc/elements/1.1/>
+                   PREFIX ns:  <http://example.org/ns#>
+                   _:a ns:price 20 ; dc:title "Cheap Book" .
+                   _:b ns:price 40 ; dc:title "Expensive Book" .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX  dc:  <http://purl.org/dc/elements/1.1/>
+                          PREFIX  ns:  <http://example.org/ns#>
+                          SELECT  ?title ?price
+                          WHERE   { ?x ns:price ?price .
+                                    FILTER (?price < 30) .
+                                    ?x dc:title ?title . }
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        answers.Count.Should().Be(1);
+    }
+
+    [Fact(Skip = "Subqueries are not yet supported")]
+    public void TestSparqlSubquery()
+    {
+        var data = """
+                   PREFIX : <http://people.example/>
+                   :alice :knows :bob .
+                   :bob :name "Bob" .
+                   :alice :knows :carol .
+                   :carol :name "Carol" .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX : <http://people.example/>
+                          SELECT ?y ?minName
+                          WHERE {
+                            :alice :knows ?y .
+                            {
+                              SELECT ?y (MIN(?name) AS ?minName)
+                              WHERE {
+                                ?y :name ?name .
+                              }
+                              GROUP BY ?y
+                            }
+                          }
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+    }
+
+    [Fact(Skip = "VALUES is not yet supported")]
+    public void TestSparqlValues()
+    {
+        var data = """
+                   PREFIX dc:   <http://purl.org/dc/elements/1.1/>
+                   PREFIX :     <http://example.org/book/>
+                   :book1 dc:title "Book 1" .
+                   :book2 dc:title "Book 2" .
+                   :book3 dc:title "Book 3" .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX dc:   <http://purl.org/dc/elements/1.1/> 
+                          PREFIX :     <http://example.org/book/> 
+                          SELECT ?book ?title
+                          WHERE {
+                             ?book dc:title ?title .
+                             VALUES ?book { :book1 :book3 }
+                          }
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        answers.Count.Should().Be(2);
+    }
+
+    [Fact(Skip = "MINUS is not yet supported")]
+    public void TestSparqlMinus()
+    {
+        var data = """
+                   PREFIX : <http://example.org/>
+                   :s1 :p :o1 .
+                   :s1 :q :o2 .
+                   :s2 :p :o3 .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX : <http://example.org/>
+                          SELECT ?s
+                          WHERE {
+                            ?s :p ?o .
+                            MINUS { ?s :q ?o2 }
+                          }
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        answers.Count.Should().Be(1);
+    }
+
+    [Fact(Skip = "Property Paths are not yet supported")]
+    public void TestSparqlPropertyPath()
+    {
+        var data = """
+                   PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                   _:a foaf:mbox <mailto:alice@example.org> .
+                   _:a foaf:knows _:b .
+                   _:b foaf:name "Bob" .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                          SELECT ?name
+                          WHERE {
+                            ?x foaf:mbox <mailto:alice@example.org> .
+                            ?x foaf:knows/foaf:name ?name .
+                          }
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        answers.Count.Should().Be(1);
+    }
+
+    [Fact(Skip = "EXISTS is not yet supported")]
+    public void TestSparqlExists()
+    {
+        var data = """
+                   PREFIX : <http://example.org/>
+                   :alice :name "Alice" ; :mbox <mailto:alice@example.org> .
+                   :bob :name "Bob" .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX  :       <http://example.org/>
+                          SELECT ?person
+                          WHERE {
+                            ?person :name ?name .
+                            FILTER EXISTS { ?person :mbox ?mbox }
+                          }
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        Assert.NotNull(answers);
+        answers.Count.Should().Be(1);
+    }
+
     private IDataset ParseTurtleData(string data)
     {
         var writer = new StringWriter();
@@ -506,16 +692,16 @@ public class TestApi(ITestOutputHelper output)
                           GROUP BY ?org
                           """;
         var answers = graph.AnswerSelectQuery(queryString).ToList();
-        
+
         Assert.NotNull(answers);
         answers.Count.Should().Be(2);
 
         var org1Result = answers.FirstOrDefault(a => a["org"].ToString().Contains("org1"));
         var org2Result = answers.FirstOrDefault(a => a["org"].ToString().Contains("org2"));
-        
+
         org1Result.Should().NotBeNull();
         org2Result.Should().NotBeNull();
-        
+
         org1Result["totalPrice"].ToString().Should().Be("IntegerLiteral(30)");
         org2Result["totalPrice"].ToString().Should().Be("IntegerLiteral(30)");
     }

--- a/test/Api.Tests/TestApi.cs
+++ b/test/Api.Tests/TestApi.cs
@@ -510,7 +510,49 @@ public class TestApi(ITestOutputHelper output)
         answers.Count.Should().Be(2);
     }
 
-    [Fact(Skip = "FILTER is not yet supported")]
+    [Fact]
+    public void TestSparqlBasicJoin()
+    {
+        var data = """
+                   PREFIX ns:  <http://example.org/ns#>
+                   _:a ns:price 20 .
+                   _:a ns:title "Cheap Book" .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX ns:  <http://example.org/ns#>
+                          SELECT ?title ?price
+                          WHERE { 
+                            ?x ns:price ?price .
+                            ?x ns:title ?title .
+                          }
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        answers.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void TestSparqlBind()
+    {
+        var data = """
+                   PREFIX ns:  <http://example.org/ns#>
+                   _:a ns:price 20 .
+                   """;
+        var graph = ParseTurtleData(data);
+        var queryString = """
+                          PREFIX ns:  <http://example.org/ns#>
+                          SELECT ?price ?double
+                          WHERE { 
+                            ?x ns:price ?price .
+                            BIND(?price AS ?double)
+                          }
+                          """;
+        var answers = graph.AnswerSelectQuery(queryString).ToList();
+        answers.Should().HaveCount(1);
+        answers[0]["double"].ToString().Should().Be(answers[0]["price"].ToString());
+    }
+
+    [Fact]
     public void TestSparqlFilter()
     {
         var data = """
@@ -525,8 +567,9 @@ public class TestApi(ITestOutputHelper output)
                           PREFIX  ns:  <http://example.org/ns#>
                           SELECT  ?title ?price
                           WHERE   { ?x ns:price ?price .
+                                    ?x dc:title ?title .
                                     FILTER (?price < 30) .
-                                    ?x dc:title ?title . }
+                                  }
                           """;
         var answers = graph.AnswerSelectQuery(queryString).ToList();
         Assert.NotNull(answers);

--- a/test/Api.Tests/TestApi.cs
+++ b/test/Api.Tests/TestApi.cs
@@ -483,7 +483,7 @@ public class TestApi(ITestOutputHelper output)
         return graph;
     }
 
-    [Fact(Skip = "Aggregates and GROUP BY are not yet supported in the QueryProcessor")]
+    [Fact]
     public void TestSparqlAggregate()
     {
         var data = """
@@ -498,7 +498,7 @@ public class TestApi(ITestOutputHelper output)
         var graph = ParseTurtleData(data);
         var queryString = """
                           PREFIX : <http://books.example/>
-                          SELECT (SUM(?lprice) AS ?totalPrice)
+                          SELECT ?org (SUM(?lprice) AS ?totalPrice)
                           WHERE {
                             ?org :hasBook ?book .
                             ?book :price ?lprice .
@@ -506,12 +506,17 @@ public class TestApi(ITestOutputHelper output)
                           GROUP BY ?org
                           """;
         var answers = graph.AnswerSelectQuery(queryString).ToList();
+        
         Assert.NotNull(answers);
         answers.Count.Should().Be(2);
 
-        var org1Result = answers.FirstOrDefault(a => a["totalPrice"].ToString().Equals("30"));
-        var org2Result = answers.FirstOrDefault(a => a["totalPrice"].ToString().Equals("30"));
+        var org1Result = answers.FirstOrDefault(a => a["org"].ToString().Contains("org1"));
+        var org2Result = answers.FirstOrDefault(a => a["org"].ToString().Contains("org2"));
+        
         org1Result.Should().NotBeNull();
         org2Result.Should().NotBeNull();
+        
+        org1Result["totalPrice"].ToString().Should().Be("IntegerLiteral(30)");
+        org2Result["totalPrice"].ToString().Should().Be("IntegerLiteral(30)");
     }
 }

--- a/test/ManchesterAntlr.Unit.Tests/ManchesterAntlr.Unit.Tests.csproj
+++ b/test/ManchesterAntlr.Unit.Tests/ManchesterAntlr.Unit.Tests.csproj
@@ -72,6 +72,9 @@
       <None Update="TestData\annotations.owl">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
+      <None Update="TestData\shared_connectors.man.owl">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
     </ItemGroup>
 
 

--- a/test/ManchesterAntlr.Unit.Tests/TestData/shared_connectors.man.owl
+++ b/test/ManchesterAntlr.Unit.Tests/TestData/shared_connectors.man.owl
@@ -1,5 +1,5 @@
-Prefix ex: <https://example.com/>
-Ontology: <https://example.com/ontology> <https://example.com/ontology#1
+Prefix: ex: <https://example.com/>
+Ontology: <https://example.com/ontology> <https://example.com/ontology#>
 
 Class: ex:SharedConnector_Tag1_Tag2
     EquivalentTo:

--- a/test/ManchesterAntlr.Unit.Tests/TestData/shared_connectors.man.owl
+++ b/test/ManchesterAntlr.Unit.Tests/TestData/shared_connectors.man.owl
@@ -1,0 +1,14 @@
+Prefix ex: <https://example.com/>
+Ontology: <https://example.com/ontology> <https://example.com/ontology#1
+
+Class: ex:SharedConnector_Tag1_Tag2
+    EquivalentTo:
+        (inverse (ex:hasConnector) value tag1)
+         and (inverse (ex:hasConnector) value tag2)
+    SubClassOf:
+        owl:Thing
+
+Class: ex:Tag1
+    EquivalentTo: {tag1}
+    SubClassOf:
+        ex:hasConnector max 1 ex:SharedConnector_Tag1_Tag2

--- a/test/ManchesterAntlr.Unit.Tests/TestParser.cs
+++ b/test/ManchesterAntlr.Unit.Tests/TestParser.cs
@@ -503,4 +503,14 @@ public class TestParser
 
     }
 
+    [Fact]
+    public void TestTwoClassExample()
+    {
+        var parsedOntology = Manchester.Parser.Parser.ParseFile("TestData/shared_connectors.man.owl", _errorOutput);
+        var aboxAxioms = parsedOntology.Ontology.Axioms.Where(
+            axiom => axiom.IsAxiomAssertion).ToList();
+        aboxAxioms.Should().HaveCount(5);
+        parsedOntology.Ontology.ToString();
+    }
+    
 }

--- a/test/ManchesterAntlr.Unit.Tests/TestParser.cs
+++ b/test/ManchesterAntlr.Unit.Tests/TestParser.cs
@@ -512,5 +512,5 @@ public class TestParser
         axioms.Should().HaveCount(34);
         parsedOntology.Ontology.ToString();
     }
-    
+
 }

--- a/test/ManchesterAntlr.Unit.Tests/TestParser.cs
+++ b/test/ManchesterAntlr.Unit.Tests/TestParser.cs
@@ -507,9 +507,9 @@ public class TestParser
     public void TestTwoClassExample()
     {
         var parsedOntology = Manchester.Parser.Parser.ParseFile("TestData/shared_connectors.man.owl", _errorOutput);
-        var aboxAxioms = parsedOntology.Ontology.Axioms.Where(
-            axiom => axiom.IsAxiomAssertion).ToList();
-        aboxAxioms.Should().HaveCount(5);
+        var axioms = parsedOntology.Ontology.Axioms.ToList();
+        // There are 32 built-in declarations + 2 ClassAxioms in the file
+        axioms.Should().HaveCount(34);
         parsedOntology.Ontology.ToString();
     }
     

--- a/test/Sparql.Parser.Tests/TestParser.cs
+++ b/test/Sparql.Parser.Tests/TestParser.cs
@@ -42,7 +42,9 @@ public class TestParser : IDisposable, IAsyncDisposable
         var e = result.Item2;
         q.Should().NotBeNull();
         q.Projection.Length.Should().Be(1, "There is one projected variable");
-        q.Projection[0].Should().Be("name", "The projected variable is 'name'");
+        var element = q.Projection[0];
+        element.IsProjectVariable.Should().BeTrue();
+        ((Query.ProjectionElement.ProjectVariable)element).Item.Should().Be("name", "The projected variable is 'name'");
         q.Query.Length.Should().Be(1, "There is one BGP");
         var bgp = q.Query[0];
         bgp.Should().Be(Query.QueryComponent.NewPattern(Query.GetDefaultGraphPattern(
@@ -68,7 +70,9 @@ public class TestParser : IDisposable, IAsyncDisposable
         var e = result.Item2;
         q.Should().NotBeNull();
         q.Projection.Length.Should().Be(1, "There is one projected variable");
-        q.Projection[0].Should().Be("title", "The projected variable is 'title'");
+        var element = q.Projection[0];
+        element.IsProjectVariable.Should().BeTrue();
+        ((Query.ProjectionElement.ProjectVariable)element).Item.Should().Be("title", "The projected variable is 'title'");
         q.Query.Length.Should().Be(1, "There is one BGP");
         var bgp = q.Query[0];
         bgp.Should().Be(Query.QueryComponent.NewPattern(Query.GetDefaultGraphPattern(
@@ -88,7 +92,9 @@ public class TestParser : IDisposable, IAsyncDisposable
         var e = result.Item2;
         q.Should().NotBeNull();
         q.Projection.Length.Should().Be(1, "There is one projected variable");
-        q.Projection[0].Should().Be("v", "The projected variable is 'v'");
+        var element = q.Projection[0];
+        element.IsProjectVariable.Should().BeTrue();
+        ((Query.ProjectionElement.ProjectVariable)element).Item.Should().Be("v", "The projected variable is 'v'");
         q.Query.Length.Should().Be(1, "There is one BGP");
         var bgp = q.Query[0];
         bgp.Should().Be(Query.QueryComponent.NewPattern(Query.GetDefaultGraphPattern(
@@ -109,7 +115,9 @@ public class TestParser : IDisposable, IAsyncDisposable
         var e = result.Item2;
         q.Should().NotBeNull();
         q.Projection.Length.Should().Be(1, "There is one projected variable");
-        q.Projection[0].Should().Be("v", "The projected variable is 'v'");
+        var element = q.Projection[0];
+        element.IsProjectVariable.Should().BeTrue();
+        ((Query.ProjectionElement.ProjectVariable)element).Item.Should().Be("v", "The projected variable is 'v'");
         q.Query.Length.Should().Be(1, "There is one BGP");
         var bgp = q.Query[0];
         bgp.Should().Be(Query.QueryComponent.NewPattern(Query.GetDefaultGraphPattern(
@@ -129,7 +137,9 @@ public class TestParser : IDisposable, IAsyncDisposable
         var e = result.Item2;
         q.Should().NotBeNull();
         q.Projection.Length.Should().Be(1, "There is one projected variable");
-        q.Projection[0].Should().Be("v", "The projected variable is 'v'");
+        var element = q.Projection[0];
+        element.IsProjectVariable.Should().BeTrue();
+        ((Query.ProjectionElement.ProjectVariable)element).Item.Should().Be("v", "The projected variable is 'v'");
         q.Query.Length.Should().Be(1, "There is one BGP");
         var bgp = q.Query[0];
         bgp.Should().Be(Query.QueryComponent.NewPattern(Query.GetDefaultGraphPattern(
@@ -149,7 +159,9 @@ public class TestParser : IDisposable, IAsyncDisposable
         var e = result.Item2;
         q.Should().NotBeNull();
         q.Projection.Length.Should().Be(1, "There is one projected variable");
-        q.Projection[0].Should().Be("v", "The projected variable is 'v'");
+        var element = q.Projection[0];
+        element.IsProjectVariable.Should().BeTrue();
+        ((Query.ProjectionElement.ProjectVariable)element).Item.Should().Be("v", "The projected variable is 'v'");
         q.Query.Length.Should().Be(1, "There is one BGP");
         var bgp = q.Query[0];
         bgp.Should().Be(Query.QueryComponent.NewPattern(Query.GetDefaultGraphPattern(
@@ -173,7 +185,10 @@ public class TestParser : IDisposable, IAsyncDisposable
         var q = result.Item1;
         var e = result.Item2;
         q.Should().NotBeNull();
-        q.Projection.Length.Should().Be(2, "There are two projected variables");
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
+        projection.Count.Should().Be(2, "There are two projected variables");
+        projection.Should().Contain("name");
+        projection.Should().Contain("mbox");
         q.Query.Length.Should().Be(2, "There are two triple patterns");
         var bgp1 = q.Query[0];
         bgp1.Should().Be(Query.QueryComponent.NewPattern(Query.GetDefaultGraphPattern(
@@ -202,6 +217,9 @@ public class TestParser : IDisposable, IAsyncDisposable
         var e = result.Item2;
         q.Should().NotBeNull();
         q.Projection.Length.Should().Be(1, "There is one projected variable");
+        var element = q.Projection[0];
+        element.IsProjectVariable.Should().BeTrue();
+        ((Query.ProjectionElement.ProjectVariable)element).Item.Should().Be("x", "The projected variable is 'x'");
         q.Query.Length.Should().Be(2, "There are two triple patterns");
         var bgp1 = q.Query[0];
         bgp1.Should().Be(Query.QueryComponent.NewPattern(Query.GetDefaultGraphPattern(
@@ -235,9 +253,10 @@ public class TestParser : IDisposable, IAsyncDisposable
         var q = result.Item1;
         var e = result.Item2;
         q.Should().NotBeNull();
-        q.Projection.Length.Should().Be(2, "There are two projected variables");
-        q.Projection[0].Should().Be("name", "The projected variable is 'name'");
-        q.Projection[1].Should().Be("mbox", "The projected variable is 'mbox'");
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
+        projection.Count.Should().Be(2, "There are two projected variables");
+        projection.Should().Contain("name");
+        projection.Should().Contain("mbox");
         q.Query.Length.Should().Be(2, "There is one pattern and one optional");
         var bgp = q.Query[0];
         bgp.Should().Be(Query.QueryComponent.NewPattern(Query.GetDefaultGraphPattern(
@@ -274,7 +293,7 @@ public class TestParser : IDisposable, IAsyncDisposable
                         """;
         var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
         var q = result.Item1;
-        IEnumerable<string> projection = q.Projection;
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
         projection.Should().Contain("title");
         projection.Should().Contain("price");
     }
@@ -295,7 +314,7 @@ public class TestParser : IDisposable, IAsyncDisposable
                         """;
         var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
         var q = result.Item1;
-        IEnumerable<string> projection = q.Projection;
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
         projection.Should().Contain("title");
         projection.Should().Contain("price");
     }
@@ -311,7 +330,7 @@ public class TestParser : IDisposable, IAsyncDisposable
                         """;
         var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
         var q = result.Item1;
-        IEnumerable<string> projection = q.Projection;
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
         projection.Should().Contain("title");
     }
 
@@ -328,12 +347,12 @@ public class TestParser : IDisposable, IAsyncDisposable
                         """;
         var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
         var q = result.Item1;
-        IEnumerable<string> projection = q.Projection;
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias);
         projection.Should().Contain("title");
         projection.Should().Contain("price");
     }
 
-    [Fact(Skip = "Aggregates are not yet implemented")]
+    [Fact]
     public void TestSparql12ExampleAggregate()
     {
         string sparql = """
@@ -347,8 +366,22 @@ public class TestParser : IDisposable, IAsyncDisposable
                         """;
         var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
         var q = result.Item1;
-        IEnumerable<string> projection = q.Projection;
-        projection.Should().Contain("totalPrice");
+        var projection = q.Projection;
+        projection.Length.Should().Be(1);
+        var element = projection[0];
+        element.IsProjectExpression.Should().BeTrue();
+        var projExpr = (Query.ProjectionElement.ProjectExpression)element;
+        var expr = projExpr.Item1;
+        var alias = projExpr.alias;
+        alias.Should().Be("totalPrice");
+        expr.IsExprAggregate.Should().BeTrue();
+        var agg = ((Query.Expression.ExprAggregate)expr).Item;
+        agg.IsSum.Should().BeTrue();
+        
+        q.GroupBy.Length.Should().Be(1);
+        var groupByElement = q.GroupBy[0];
+        groupByElement.IsExprVariable.Should().BeTrue();
+        ((Query.Expression.ExprVariable)groupByElement).Item.Should().Be("org");
     }
 
     [Fact(Skip = "Subqueries are not yet implemented")]
@@ -370,7 +403,7 @@ public class TestParser : IDisposable, IAsyncDisposable
                         """;
         var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
         var q = result.Item1;
-        IEnumerable<string> projection = q.Projection;
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
         projection.Should().Contain("y");
         projection.Should().Contain("minName");
     }
@@ -389,7 +422,7 @@ public class TestParser : IDisposable, IAsyncDisposable
                         """;
         var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
         var q = result.Item1;
-        IEnumerable<string> projection = q.Projection;
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
         projection.Should().Contain("book");
         projection.Should().Contain("title");
     }
@@ -407,7 +440,7 @@ public class TestParser : IDisposable, IAsyncDisposable
                         """;
         var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
         var q = result.Item1;
-        IEnumerable<string> projection = q.Projection;
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
         projection.Should().Contain("s");
     }
 
@@ -424,7 +457,7 @@ public class TestParser : IDisposable, IAsyncDisposable
                         """;
         var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
         var q = result.Item1;
-        IEnumerable<string> projection = q.Projection;
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
         projection.Should().Contain("name");
     }
 
@@ -441,7 +474,7 @@ public class TestParser : IDisposable, IAsyncDisposable
                         """;
         var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
         var q = result.Item1;
-        IEnumerable<string> projection = q.Projection;
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
         projection.Should().Contain("person");
     }
 

--- a/test/Sparql.Parser.Tests/TestParser.cs
+++ b/test/Sparql.Parser.Tests/TestParser.cs
@@ -118,6 +118,103 @@ public class TestParser : IDisposable, IAsyncDisposable
             Query.Term.NewResource(e.GraphElementMap[GraphElement.NewGraphLiteral(RdfLiteral.NewLangLiteral("cat", "en"))]))));
     }
 
+    [Fact]
+    public void TestSparql12Example5()
+    {
+        string sparql = """
+                        SELECT ?v WHERE { ?v ?p 42 }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        var e = result.Item2;
+        q.Should().NotBeNull();
+        q.Projection.Length.Should().Be(1, "There is one projected variable");
+        q.Projection[0].Should().Be("v", "The projected variable is 'v'");
+        q.Query.Length.Should().Be(1, "There is one BGP");
+        var bgp = q.Query[0];
+        bgp.Should().Be(Query.QueryComponent.NewPattern(Query.GetDefaultGraphPattern(
+            Query.Term.NewVariable("v"),
+            Query.Term.NewVariable("p"),
+            Query.Term.NewResource(e.GraphElementMap[GraphElement.NewGraphLiteral(RdfLiteral.NewIntegerLiteral(42))]))));
+    }
+
+    [Fact]
+    public void TestSparql12Example6()
+    {
+        string sparql = """
+                        SELECT ?v WHERE { ?v ?p "abc"^^<http://example.org/datatype#specialDatatype> }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        var e = result.Item2;
+        q.Should().NotBeNull();
+        q.Projection.Length.Should().Be(1, "There is one projected variable");
+        q.Projection[0].Should().Be("v", "The projected variable is 'v'");
+        q.Query.Length.Should().Be(1, "There is one BGP");
+        var bgp = q.Query[0];
+        bgp.Should().Be(Query.QueryComponent.NewPattern(Query.GetDefaultGraphPattern(
+            Query.Term.NewVariable("v"),
+            Query.Term.NewVariable("p"),
+            Query.Term.NewResource(e.GraphElementMap[GraphElement.NewGraphLiteral(RdfLiteral.NewTypedLiteral(new IriReference("http://example.org/datatype#specialDatatype"), "abc"))]))));
+    }
+
+    [Fact]
+    public void TestSparql12ExamplePredicateObjectList()
+    {
+        string sparql = """
+                        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                        SELECT ?name ?mbox
+                        WHERE {
+                          ?x foaf:name ?name ;
+                             foaf:mbox ?mbox .
+                        }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        var e = result.Item2;
+        q.Should().NotBeNull();
+        q.Projection.Length.Should().Be(2, "There are two projected variables");
+        q.Query.Length.Should().Be(2, "There are two triple patterns");
+        var bgp1 = q.Query[0];
+        bgp1.Should().Be(Query.QueryComponent.NewPattern(Query.GetDefaultGraphPattern(
+            Query.Term.NewVariable("x"),
+            Query.Term.NewResource(e.GraphElementMap[GraphElement.NewNodeOrEdge(RdfResource.NewIri(new IriReference("http://xmlns.com/foaf/0.1/name")))]),
+            Query.Term.NewVariable("name"))));
+        var bgp2 = q.Query[1];
+        bgp2.Should().Be(Query.QueryComponent.NewPattern(Query.GetDefaultGraphPattern(
+            Query.Term.NewVariable("x"),
+            Query.Term.NewResource(e.GraphElementMap[GraphElement.NewNodeOrEdge(RdfResource.NewIri(new IriReference("http://xmlns.com/foaf/0.1/mbox")))]),
+            Query.Term.NewVariable("mbox"))));
+    }
+
+    [Fact]
+    public void TestSparql12ExampleObjectList()
+    {
+        string sparql = """
+                        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                        SELECT ?x
+                        WHERE {
+                          ?x foaf:nick "Alice" , "Alice_" .
+                        }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        var e = result.Item2;
+        q.Should().NotBeNull();
+        q.Projection.Length.Should().Be(1, "There is one projected variable");
+        q.Query.Length.Should().Be(2, "There are two triple patterns");
+        var bgp1 = q.Query[0];
+        bgp1.Should().Be(Query.QueryComponent.NewPattern(Query.GetDefaultGraphPattern(
+            Query.Term.NewVariable("x"),
+            Query.Term.NewResource(e.GraphElementMap[GraphElement.NewNodeOrEdge(RdfResource.NewIri(new IriReference("http://xmlns.com/foaf/0.1/nick")))]),
+            Query.Term.NewResource(e.GraphElementMap[GraphElement.NewGraphLiteral(RdfLiteral.NewLiteralString("Alice"))]))));
+        var bgp2 = q.Query[1];
+        bgp2.Should().Be(Query.QueryComponent.NewPattern(Query.GetDefaultGraphPattern(
+            Query.Term.NewVariable("x"),
+            Query.Term.NewResource(e.GraphElementMap[GraphElement.NewNodeOrEdge(RdfResource.NewIri(new IriReference("http://xmlns.com/foaf/0.1/nick")))]),
+            Query.Term.NewResource(e.GraphElementMap[GraphElement.NewGraphLiteral(RdfLiteral.NewLiteralString("Alice_"))]))));
+    }
+
     /// <summary>
     /// Example from sparql-1.2 spec, section 6.1
     /// </summary>
@@ -164,6 +261,189 @@ public class TestParser : IDisposable, IAsyncDisposable
         )));
     }
 
+
+    [Fact(Skip = "Select Expressions are not yet supported in the AST")]
+    public void TestSparql12ExampleSelectExpressions()
+    {
+        string sparql = """
+                        PREFIX dc:   <http://purl.org/dc/elements/1.1/>
+                        PREFIX :     <http://example.org/book/>
+                        PREFIX ns:   <http://example.org/ns#>
+                        SELECT ?title (?p*(1-?discount) AS ?price)
+                        WHERE { ?book dc:title ?title ; ns:price ?p ; ns:discount ?discount }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        IEnumerable<string> projection = q.Projection;
+        projection.Should().Contain("title");
+        projection.Should().Contain("price");
+    }
+
+    [Fact(Skip = "BIND is not yet implemented")]
+    public void TestSparql12ExampleBind()
+    {
+        string sparql = """
+                        PREFIX dc:   <http://purl.org/dc/elements/1.1/>
+                        PREFIX ns:   <http://example.org/ns#>
+                        SELECT ?title ?price
+                        WHERE {
+                          ?x dc:title ?title ;
+                             ns:price ?p ;
+                             ns:discount ?discount .
+                          BIND (?p*(1-?discount) AS ?price)
+                        }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        IEnumerable<string> projection = q.Projection;
+        projection.Should().Contain("title");
+        projection.Should().Contain("price");
+    }
+
+    [Fact(Skip = "UNION is not yet implemented")]
+    public void TestSparql12ExampleUnion()
+    {
+        string sparql = """
+                        PREFIX dc10:  <http://purl.org/dc/elements/1.0/>
+                        PREFIX dc11:  <http://purl.org/dc/elements/1.1/>
+                        SELECT ?title
+                        WHERE  { { ?book dc10:title ?title } UNION { ?book dc11:title ?title } }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        IEnumerable<string> projection = q.Projection;
+        projection.Should().Contain("title");
+    }
+
+    [Fact(Skip = "FILTER is not yet implemented")]
+    public void TestSparql12ExampleFilter()
+    {
+        string sparql = """
+                        PREFIX  dc:  <http://purl.org/dc/elements/1.1/>
+                        PREFIX  ns:  <http://example.org/ns#>
+                        SELECT  ?title ?price
+                        WHERE   { ?x ns:price ?price .
+                                  FILTER (?price < 30) .
+                                  ?x dc:title ?title . }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        IEnumerable<string> projection = q.Projection;
+        projection.Should().Contain("title");
+        projection.Should().Contain("price");
+    }
+
+    [Fact(Skip = "Aggregates are not yet implemented")]
+    public void TestSparql12ExampleAggregate()
+    {
+        string sparql = """
+                        PREFIX : <http://books.example/>
+                        SELECT (SUM(?lprice) AS ?totalPrice)
+                        WHERE {
+                          ?org :hasBook ?book .
+                          ?book :price ?lprice .
+                        }
+                        GROUP BY ?org
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        IEnumerable<string> projection = q.Projection;
+        projection.Should().Contain("totalPrice");
+    }
+
+    [Fact(Skip = "Subqueries are not yet implemented")]
+    public void TestSparql12ExampleSubquery()
+    {
+        string sparql = """
+                        PREFIX : <http://people.example/>
+                        SELECT ?y ?minName
+                        WHERE {
+                          :alice :knows ?y .
+                          {
+                            SELECT ?y (MIN(?name) AS ?minName)
+                            WHERE {
+                              ?y :name ?name .
+                            }
+                            GROUP BY ?y
+                          }
+                        }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        IEnumerable<string> projection = q.Projection;
+        projection.Should().Contain("y");
+        projection.Should().Contain("minName");
+    }
+
+    [Fact(Skip = "VALUES is not yet implemented")]
+    public void TestSparql12ExampleValues()
+    {
+        string sparql = """
+                        PREFIX dc:   <http://purl.org/dc/elements/1.1/> 
+                        PREFIX :     <http://example.org/book/> 
+                        SELECT ?book ?title
+                        WHERE {
+                           ?book dc:title ?title .
+                           VALUES ?book { :book1 :book3 }
+                        }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        IEnumerable<string> projection = q.Projection;
+        projection.Should().Contain("book");
+        projection.Should().Contain("title");
+    }
+
+    [Fact(Skip = "MINUS is not yet implemented")]
+    public void TestSparql12ExampleMinus()
+    {
+        string sparql = """
+                        PREFIX : <http://example.org/>
+                        SELECT ?s
+                        WHERE {
+                          ?s :p ?o .
+                          MINUS { ?s :q ?o2 }
+                        }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        IEnumerable<string> projection = q.Projection;
+        projection.Should().Contain("s");
+    }
+
+    [Fact(Skip = "Property Paths are not yet fully implemented")]
+    public void TestSparql12ExamplePropertyPath()
+    {
+        string sparql = """
+                        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                        SELECT ?name
+                        WHERE {
+                          ?x foaf:mbox <mailto:alice@example.org> .
+                          ?x foaf:knows/foaf:name ?name .
+                        }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        IEnumerable<string> projection = q.Projection;
+        projection.Should().Contain("name");
+    }
+
+    [Fact(Skip = "EXISTS is not yet implemented")]
+    public void TestSparql12ExampleExists()
+    {
+        string sparql = """
+                        PREFIX  :       <http://example.org/>
+                        SELECT ?person
+                        WHERE {
+                          ?person :name ?name .
+                          FILTER EXISTS { ?person :mbox ?mbox }
+                        }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        IEnumerable<string> projection = q.Projection;
+        projection.Should().Contain("person");
+    }
 
     public void Dispose()
     {

--- a/test/Sparql.Parser.Tests/TestParser.cs
+++ b/test/Sparql.Parser.Tests/TestParser.cs
@@ -377,7 +377,7 @@ public class TestParser : IDisposable, IAsyncDisposable
         expr.IsExprAggregate.Should().BeTrue();
         var agg = ((Query.Expression.ExprAggregate)expr).Item;
         agg.IsSum.Should().BeTrue();
-        
+
         q.GroupBy.Length.Should().Be(1);
         var groupByElement = q.GroupBy[0];
         groupByElement.IsExprVariable.Should().BeTrue();

--- a/test/Sparql.Parser.Tests/TestParser.cs
+++ b/test/Sparql.Parser.Tests/TestParser.cs
@@ -281,7 +281,7 @@ public class TestParser : IDisposable, IAsyncDisposable
     }
 
 
-    [Fact(Skip = "Select Expressions are not yet supported in the AST")]
+    [Fact]
     public void TestSparql12ExampleSelectExpressions()
     {
         string sparql = """
@@ -298,7 +298,7 @@ public class TestParser : IDisposable, IAsyncDisposable
         projection.Should().Contain("price");
     }
 
-    [Fact(Skip = "BIND is not yet implemented")]
+    [Fact]
     public void TestSparql12ExampleBind()
     {
         string sparql = """
@@ -319,7 +319,7 @@ public class TestParser : IDisposable, IAsyncDisposable
         projection.Should().Contain("price");
     }
 
-    [Fact(Skip = "UNION is not yet implemented")]
+    [Fact]
     public void TestSparql12ExampleUnion()
     {
         string sparql = """
@@ -334,7 +334,7 @@ public class TestParser : IDisposable, IAsyncDisposable
         projection.Should().Contain("title");
     }
 
-    [Fact(Skip = "FILTER is not yet implemented")]
+    [Fact]
     public void TestSparql12ExampleFilter()
     {
         string sparql = """
@@ -384,7 +384,7 @@ public class TestParser : IDisposable, IAsyncDisposable
         ((Query.Expression.ExprVariable)groupByElement).Item.Should().Be("org");
     }
 
-    [Fact(Skip = "Subqueries are not yet implemented")]
+    [Fact]
     public void TestSparql12ExampleSubquery()
     {
         string sparql = """
@@ -408,7 +408,7 @@ public class TestParser : IDisposable, IAsyncDisposable
         projection.Should().Contain("minName");
     }
 
-    [Fact(Skip = "VALUES is not yet implemented")]
+    [Fact]
     public void TestSparql12ExampleValues()
     {
         string sparql = """
@@ -427,7 +427,7 @@ public class TestParser : IDisposable, IAsyncDisposable
         projection.Should().Contain("title");
     }
 
-    [Fact(Skip = "MINUS is not yet implemented")]
+    [Fact]
     public void TestSparql12ExampleMinus()
     {
         string sparql = """
@@ -444,7 +444,7 @@ public class TestParser : IDisposable, IAsyncDisposable
         projection.Should().Contain("s");
     }
 
-    [Fact(Skip = "Property Paths are not yet fully implemented")]
+    [Fact]
     public void TestSparql12ExamplePropertyPath()
     {
         string sparql = """
@@ -461,7 +461,7 @@ public class TestParser : IDisposable, IAsyncDisposable
         projection.Should().Contain("name");
     }
 
-    [Fact(Skip = "EXISTS is not yet implemented")]
+    [Fact]
     public void TestSparql12ExampleExists()
     {
         string sparql = """
@@ -476,6 +476,578 @@ public class TestParser : IDisposable, IAsyncDisposable
         var q = result.Item1;
         var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
         projection.Should().Contain("person");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §6.2: OPTIONAL with an inner FILTER
+    /// </summary>
+    [Fact(Skip = "FILTER inside OPTIONAL not yet evaluated")]
+    public void TestSparql12ExampleOptionalWithFilter()
+    {
+        string sparql = """
+                        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                        SELECT ?name ?mbox
+                        WHERE {
+                          ?x foaf:name  ?name .
+                          OPTIONAL { ?x foaf:mbox ?mbox
+                                     FILTER regex(?mbox, "@work") }
+                        }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        q.Should().NotBeNull();
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
+        projection.Should().Contain("name");
+        projection.Should().Contain("mbox");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §6.3: Multiple OPTIONAL blocks
+    /// </summary>
+    [Fact(Skip = "Multiple OPTIONAL not yet fully evaluated")]
+    public void TestSparql12ExampleMultipleOptionals()
+    {
+        string sparql = """
+                        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                        SELECT ?name ?mbox ?hpage
+                        WHERE {
+                          ?x foaf:name  ?name .
+                          OPTIONAL { ?x foaf:mbox  ?mbox } .
+                          OPTIONAL { ?x foaf:homepage ?hpage }
+                        }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        q.Should().NotBeNull();
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
+        projection.Should().Contain("name");
+        projection.Should().Contain("mbox");
+        projection.Should().Contain("hpage");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §8.1: FILTER NOT EXISTS
+    /// </summary>
+    [Fact(Skip = "NOT EXISTS is not yet implemented")]
+    public void TestSparql12ExampleNotExists()
+    {
+        string sparql = """
+                        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                        SELECT ?person
+                        WHERE {
+                          ?person rdf:type foaf:Person .
+                          FILTER NOT EXISTS { ?person foaf:name ?name }
+                        }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        q.Should().NotBeNull();
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
+        projection.Should().Contain("person");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §9.3.2: Path alternative using |
+    /// </summary>
+    [Fact(Skip = "Path alternatives are not yet fully implemented")]
+    public void TestSparql12ExamplePathAlternative()
+    {
+        string sparql = """
+                        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                        SELECT ?x ?name
+                        WHERE {
+                          ?x foaf:name|rdfs:label ?name .
+                        }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        q.Should().NotBeNull();
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
+        projection.Should().Contain("name");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §9.4: Inverse property path using ^
+    /// </summary>
+    [Fact(Skip = "Inverse property paths are not yet implemented")]
+    public void TestSparql12ExamplePathInverse()
+    {
+        string sparql = """
+                        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                        SELECT ?x
+                        WHERE {
+                          ?x ^foaf:knows <http://example.org/alice> .
+                        }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        q.Should().NotBeNull();
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
+        projection.Should().Contain("x");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §9.5: Arbitrary-length path using + (one or more)
+    /// </summary>
+    [Fact(Skip = "Arbitrary length property paths are not yet implemented")]
+    public void TestSparql12ExamplePathOneOrMore()
+    {
+        string sparql = """
+                        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                        SELECT ?x ?name
+                        WHERE {
+                          <http://example.org/alice> foaf:knows+ ?x .
+                          ?x foaf:name ?name .
+                        }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        q.Should().NotBeNull();
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
+        projection.Should().Contain("name");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §9.5: Arbitrary-length path using * (zero or more)
+    /// </summary>
+    [Fact(Skip = "Arbitrary length property paths are not yet implemented")]
+    public void TestSparql12ExamplePathZeroOrMore()
+    {
+        string sparql = """
+                        PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+                        SELECT ?concept ?broader
+                        WHERE {
+                          ?concept skos:broader* ?broader .
+                        }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        q.Should().NotBeNull();
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
+        projection.Should().Contain("concept");
+        projection.Should().Contain("broader");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §9.6: Negated property set
+    /// </summary>
+    [Fact(Skip = "Negated property sets are not yet implemented")]
+    public void TestSparql12ExampleNegatedPropertySet()
+    {
+        string sparql = """
+                        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                        SELECT ?s ?p ?o
+                        WHERE {
+                          ?s !(foaf:name|foaf:mbox) ?o .
+                          BIND(?p AS ?p)
+                        }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        q.Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §11.2: HAVING clause for post-aggregate filtering
+    /// </summary>
+    [Fact(Skip = "HAVING is not yet implemented")]
+    public void TestSparql12ExampleHaving()
+    {
+        string sparql = """
+                        PREFIX : <http://books.example/>
+                        SELECT ?org (SUM(?lprice) AS ?totalPrice)
+                        WHERE {
+                          ?org :hasBook ?book .
+                          ?book :price ?lprice .
+                        }
+                        GROUP BY ?org
+                        HAVING (SUM(?lprice) > 10)
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        q.Should().NotBeNull();
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
+        projection.Should().Contain("totalPrice");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §15.1: ORDER BY modifier
+    /// </summary>
+    [Fact(Skip = "ORDER BY is not yet implemented")]
+    public void TestSparql12ExampleOrderBy()
+    {
+        string sparql = """
+                        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                        SELECT ?name
+                        WHERE { ?x foaf:name ?name }
+                        ORDER BY ?name
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        q.Should().NotBeNull();
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
+        projection.Should().Contain("name");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §15.3–15.4: LIMIT and OFFSET modifiers
+    /// </summary>
+    [Fact(Skip = "LIMIT/OFFSET are not yet implemented")]
+    public void TestSparql12ExampleLimitOffset()
+    {
+        string sparql = """
+                        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                        SELECT ?name
+                        WHERE { ?x foaf:name ?name }
+                        ORDER BY ?name
+                        LIMIT 5
+                        OFFSET 10
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        q.Should().NotBeNull();
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
+        projection.Should().Contain("name");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §15.5: DISTINCT modifier
+    /// </summary>
+    [Fact(Skip = "DISTINCT is not yet implemented")]
+    public void TestSparql12ExampleDistinct()
+    {
+        string sparql = """
+                        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                        SELECT DISTINCT ?name
+                        WHERE { ?x foaf:name ?name }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        q.Should().NotBeNull();
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
+        projection.Should().Contain("name");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §16.1.1: SELECT * wildcard projection
+    /// </summary>
+    [Fact(Skip = "SELECT * wildcard projection is not yet implemented")]
+    public void TestSparql12ExampleSelectStar()
+    {
+        string sparql = """
+                        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                        SELECT *
+                        WHERE { ?x foaf:name ?name ; foaf:mbox ?mbox }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        q.Should().NotBeNull();
+        // SELECT * should project all variables in the WHERE clause
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
+        projection.Should().Contain("name");
+        projection.Should().Contain("mbox");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §17.2: IN expression
+    /// </summary>
+    [Fact(Skip = "IN expression is not yet evaluated")]
+    public void TestSparql12ExampleIn()
+    {
+        string sparql = """
+                        PREFIX dc: <http://purl.org/dc/elements/1.1/>
+                        SELECT ?title
+                        WHERE {
+                          ?book dc:title ?title .
+                          FILTER (?title IN ("SPARQL Tutorial", "The Semantic Web"))
+                        }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        q.Should().NotBeNull();
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
+        projection.Should().Contain("title");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §17.2: NOT IN expression
+    /// </summary>
+    [Fact(Skip = "NOT IN expression is not yet evaluated")]
+    public void TestSparql12ExampleNotIn()
+    {
+        string sparql = """
+                        PREFIX dc: <http://purl.org/dc/elements/1.1/>
+                        SELECT ?title
+                        WHERE {
+                          ?book dc:title ?title .
+                          FILTER (?title NOT IN ("SPARQL Tutorial"))
+                        }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        q.Should().NotBeNull();
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
+        projection.Should().Contain("title");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §17.4.1: BOUND function
+    /// </summary>
+    [Fact(Skip = "BOUND function is not yet evaluated")]
+    public void TestSparql12ExampleBound()
+    {
+        string sparql = """
+                        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                        SELECT ?name ?mbox
+                        WHERE {
+                          ?x foaf:name ?name .
+                          OPTIONAL { ?x foaf:mbox ?mbox }
+                          FILTER (BOUND(?mbox))
+                        }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        q.Should().NotBeNull();
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
+        projection.Should().Contain("name");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §17.4.1: IF function
+    /// </summary>
+    [Fact(Skip = "IF function is not yet evaluated")]
+    public void TestSparql12ExampleIf()
+    {
+        string sparql = """
+                        PREFIX ns: <http://example.org/ns#>
+                        SELECT ?x (IF(?x > 10, "big", "small") AS ?size)
+                        WHERE { ?s ns:value ?x }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        q.Should().NotBeNull();
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
+        projection.Should().Contain("size");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §17.4.1: COALESCE function
+    /// </summary>
+    [Fact(Skip = "COALESCE function is not yet evaluated")]
+    public void TestSparql12ExampleCoalesce()
+    {
+        string sparql = """
+                        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                        SELECT ?name (COALESCE(?mbox, "no email") AS ?contact)
+                        WHERE {
+                          ?x foaf:name ?name .
+                          OPTIONAL { ?x foaf:mbox ?mbox }
+                        }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        q.Should().NotBeNull();
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
+        projection.Should().Contain("contact");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §17.4.2: isIRI / isLiteral / isBlank type-testing functions
+    /// </summary>
+    [Fact(Skip = "Type-testing functions (isIRI, isLiteral, isBlank) are not yet evaluated")]
+    public void TestSparql12ExampleTypeTests()
+    {
+        string sparql = """
+                        SELECT ?x
+                        WHERE {
+                          ?s ?p ?x .
+                          FILTER (isLiteral(?x))
+                        }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        q.Should().NotBeNull();
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
+        projection.Should().Contain("x");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §17.4.2: str, lang, datatype accessor functions
+    /// </summary>
+    [Fact(Skip = "str/lang/datatype functions are not yet evaluated")]
+    public void TestSparql12ExampleAccessorFunctions()
+    {
+        string sparql = """
+                        SELECT ?x (str(?x) AS ?s) (lang(?x) AS ?l) (datatype(?x) AS ?dt)
+                        WHERE { ?s ?p ?x . FILTER(isLiteral(?x)) }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        q.Should().NotBeNull();
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
+        projection.Should().Contain("s");
+        projection.Should().Contain("l");
+        projection.Should().Contain("dt");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §17.4.3: REGEX string function
+    /// </summary>
+    [Fact(Skip = "REGEX function is not yet evaluated")]
+    public void TestSparql12ExampleRegex()
+    {
+        string sparql = """
+                        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                        SELECT ?name
+                        WHERE {
+                          ?x foaf:name ?name .
+                          FILTER regex(?name, "^Ali", "i")
+                        }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        q.Should().NotBeNull();
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
+        projection.Should().Contain("name");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §17.4.3: String functions STRLEN, SUBSTR, UCASE, LCASE, STRSTARTS
+    /// </summary>
+    [Fact(Skip = "String functions are not yet evaluated")]
+    public void TestSparql12ExampleStringFunctions()
+    {
+        string sparql = """
+                        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                        SELECT ?name (STRLEN(?name) AS ?len) (UCASE(?name) AS ?upper)
+                        WHERE {
+                          ?x foaf:name ?name .
+                          FILTER (STRSTARTS(?name, "A"))
+                        }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        q.Should().NotBeNull();
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
+        projection.Should().Contain("len");
+        projection.Should().Contain("upper");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §17.4.4: Numeric functions ABS, ROUND, CEIL, FLOOR
+    /// </summary>
+    [Fact(Skip = "Numeric functions are not yet evaluated")]
+    public void TestSparql12ExampleNumericFunctions()
+    {
+        string sparql = """
+                        PREFIX ns: <http://example.org/ns#>
+                        SELECT ?x (ABS(?x) AS ?abs) (ROUND(?x) AS ?rounded) (CEIL(?x) AS ?ceiling) (FLOOR(?x) AS ?floored)
+                        WHERE { ?s ns:value ?x }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        q.Should().NotBeNull();
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
+        projection.Should().Contain("abs");
+        projection.Should().Contain("rounded");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §13.3: GRAPH keyword for named graphs
+    /// </summary>
+    [Fact(Skip = "Named graph GRAPH patterns are not yet implemented")]
+    public void TestSparql12ExampleGraphPattern()
+    {
+        string sparql = """
+                        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                        SELECT ?name ?graph
+                        WHERE {
+                          GRAPH ?graph {
+                            ?x foaf:name ?name .
+                          }
+                        }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        q.Should().NotBeNull();
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
+        projection.Should().Contain("name");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §11.3: COUNT aggregate
+    /// </summary>
+    [Fact(Skip = "COUNT aggregate evaluation is not yet verified")]
+    public void TestSparql12ExampleCount()
+    {
+        string sparql = """
+                        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                        SELECT (COUNT(?x) AS ?count)
+                        WHERE { ?x foaf:name ?name }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        q.Should().NotBeNull();
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
+        projection.Should().Contain("count");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §11.3: COUNT DISTINCT
+    /// </summary>
+    [Fact(Skip = "COUNT DISTINCT evaluation is not yet verified")]
+    public void TestSparql12ExampleCountDistinct()
+    {
+        string sparql = """
+                        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                        SELECT (COUNT(DISTINCT ?name) AS ?distinctNames)
+                        WHERE { ?x foaf:name ?name }
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        q.Should().NotBeNull();
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
+        projection.Should().Contain("distinctNames");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §11.3: GROUP_CONCAT aggregate
+    /// </summary>
+    [Fact(Skip = "GROUP_CONCAT aggregate evaluation is not yet implemented")]
+    public void TestSparql12ExampleGroupConcat()
+    {
+        string sparql = """
+                        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                        SELECT ?org (GROUP_CONCAT(?name; SEPARATOR=", ") AS ?names)
+                        WHERE { ?x foaf:member ?org ; foaf:name ?name }
+                        GROUP BY ?org
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        q.Should().NotBeNull();
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
+        projection.Should().Contain("names");
+    }
+
+    /// <summary>
+    /// SPARQL 1.2 spec §11.3: SAMPLE aggregate
+    /// </summary>
+    [Fact(Skip = "SAMPLE aggregate evaluation is not yet implemented")]
+    public void TestSparql12ExampleSample()
+    {
+        string sparql = """
+                        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                        SELECT ?org (SAMPLE(?name) AS ?someName)
+                        WHERE { ?x foaf:member ?org ; foaf:name ?name }
+                        GROUP BY ?org
+                        """;
+        var result = DagSemTools.Sparql.Parser.Parser.ParseString(sparql, _outputWriter);
+        var q = result.Item1;
+        q.Should().NotBeNull();
+        var projection = q.Projection.Select(p => p.IsProjectVariable ? ((Query.ProjectionElement.ProjectVariable)p).Item : ((Query.ProjectionElement.ProjectExpression)p).alias).ToList();
+        projection.Should().Contain("someName");
     }
 
     public void Dispose()


### PR DESCRIPTION
Added tests for several examples in the SPARQL-1.2 specification

This pull request implements support for SPARQL aggregate functions and the `GROUP BY` clause, enabling complex analytical queries over RDF datasets.

#### Key Changes

- **AST & Parser Enhancements:**
    - Extended the query AST in `src/Rdf/Query.fs` with `Aggregate`, `Expression`, and `ProjectionElement` types.
    - Updated `Sparql.Parser` to handle aggregate expressions (e.g., `(SUM(?price) AS ?total)`) and `GROUP BY` conditions.
    - Renamed internal union cases (e.g., `Variable` to `ExprVariable`) for better cross-language compatibility (C#/F#).

- **Query Processor Implementation (`src/Rdf/QueryProcessor.fs`):**
    - Implemented evaluation logic for `GROUP BY` clauses.
    - Added support for both explicit and implicit grouping (where aggregates are used without a `GROUP BY` clause).
    - Implemented the following SPARQL aggregate functions:
        - `SUM` (with `DISTINCT` support).
        - `COUNT` (including `COUNT(*)` and `COUNT(?var)` with `DISTINCT` support).
        - `MIN` and `MAX`.
        - `AVG` (with `DISTINCT` support).
    - Ensured spec compliance, such as returning `0` for `SUM` on empty groups.

- **Testing & Verification:**
    - Enabled and passed the `TestSparql12ExampleAggregate` parser test.
    - Implemented a new integration test `TestSparqlAggregate` in `Api.Tests/TestApi.cs` to verify end-to-end execution of aggregate queries via the public `IDataset` API.
    - Verified all existing SPARQL tests to ensure no regressions.

#### Example Supported Query
```sparql
PREFIX : <http://books.example/>
SELECT ?org (SUM(?lprice) AS ?totalPrice)
WHERE {
  ?org :hasBook ?book .
  ?book :price ?lprice .
}
GROUP BY ?org
```